### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,13 @@ jobs:
         # sibling directory it expects.
         run: git clone --depth 1 https://github.com/thestk/rtaudio.git ../rtaudio
 
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: C:\vcpkg\installed
+          key: vcpkg-x64-windows-opus-portaudio-hidapi-openssl-eigen3-qcustomplot
+          restore-keys: vcpkg-x64-windows-
+
       - name: Install vcpkg packages
         shell: pwsh
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Clone QCustomPlot
         # vcpkg's qcustomplot is built against Qt6; compile from source for Qt5 compatibility.
-        run: git clone --depth 1 --branch 2.1.1 https://gitlab.com/DerManu/QCustomPlot.git ../qcustomplot
+        run: git clone --depth 1 https://gitlab.com/DerManu/QCustomPlot.git ../qcustomplot
 
       - name: Build
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,9 +167,14 @@ jobs:
             vcpkg install "${pkg}:${triplet}"
           }
 
-      - name: Clone QCustomPlot
+      - name: Get QCustomPlot source
         # vcpkg's qcustomplot is built against Qt6; compile from source for Qt5 compatibility.
-        run: git clone --depth 1 https://gitlab.com/DerManu/QCustomPlot.git ../qcustomplot
+        # The official GitLab repo contains only a README; download the release tarball instead.
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://www.qcustomplot.com/release/2.1.1/QCustomPlot-source.tar.gz" -OutFile "qcp-source.tar.gz"
+          New-Item -ItemType Directory -Force -Path "..\qcustomplot"
+          tar -xzf qcp-source.tar.gz -C ..\qcustomplot --strip-components=1
 
       - name: Build
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\vcpkg\installed
-          key: vcpkg-x64-windows-opus-portaudio-hidapi-openssl-eigen3-qcustomplot
+          key: vcpkg-x64-windows-opus-portaudio-hidapi-openssl-eigen3
           restore-keys: vcpkg-x64-windows-
           save-always: true
 
@@ -162,30 +162,20 @@ jobs:
         run: |
           $env:VCPKG_ROOT = "C:\vcpkg"  # suppress MSVC-bundled vcpkg mismatch warning
           $triplet = "x64-windows"
-          $pkgs = "opus", "portaudio", "hidapi", "openssl", "eigen3", "qcustomplot"
+          $pkgs = "opus", "portaudio", "hidapi", "openssl", "eigen3"
           foreach ($pkg in $pkgs) {
             vcpkg install "${pkg}:${triplet}"
           }
-          # Alias qcustomplot → qcustomplot2 to match the lib name used in wfview.pro
-          $lib = "C:\vcpkg\installed\$triplet\lib"
-          if (Test-Path "$lib\qcustomplot.lib") {
-            Copy-Item "$lib\qcustomplot.lib" "$lib\qcustomplot2.lib"
-          }
-          $bin = "C:\vcpkg\installed\$triplet\bin"
-          if (Test-Path "$bin\qcustomplot.dll") {
-            Copy-Item "$bin\qcustomplot.dll" "$bin\qcustomplot2.dll"
-          }
 
-      - name: List vcpkg libs (diagnostic)
-        shell: pwsh
-        run: Get-ChildItem "C:\vcpkg\installed\x64-windows\lib" | Select-Object Name | Sort-Object Name
+      - name: Clone QCustomPlot
+        # vcpkg's qcustomplot is built against Qt6; compile from source for Qt5 compatibility.
+        run: git clone --depth 1 --branch 2.1.1 https://gitlab.com/DerManu/QCustomPlot.git ../qcustomplot
 
       - name: Build
         shell: cmd
-        env:
-          VCPKG_DIR: C:\vcpkg\installed\x64-windows
         run: |
-          qmake wfview.pro CONFIG+=release
+          echo VCPKG_DIR=C:\vcpkg\installed\x64-windows
+          qmake wfview.pro CONFIG+=release "VCPKG_DIR=C:/vcpkg/installed/x64-windows"
           nmake release
 
       - name: Get version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,99 @@ jobs:
           path: wfweb_*_${{ matrix.deb_arch }}.deb
           retention-days: 30
 
+  build-windows:
+    name: Windows x64
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Qt5
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '5.15.2'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2019_64'
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Clone RTAudio
+        # The .pro compiles RTAudio from source on non-Linux; clone to the
+        # sibling directory it expects.
+        run: git clone --depth 1 https://github.com/thestk/rtaudio.git ../rtaudio
+
+      - name: Install vcpkg packages
+        shell: pwsh
+        run: |
+          $triplet = "x64-windows"
+          $pkgs = "opus", "portaudio", "hidapi", "openssl", "eigen3", "qcustomplot"
+          foreach ($pkg in $pkgs) {
+            vcpkg install "${pkg}:${triplet}"
+          }
+          # Alias qcustomplot → qcustomplot2 to match the lib name used in wfview.pro
+          $lib = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
+          if (Test-Path "$lib\qcustomplot.lib") {
+            Copy-Item "$lib\qcustomplot.lib" "$lib\qcustomplot2.lib"
+          }
+          $bin = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\bin"
+          if (Test-Path "$bin\qcustomplot.dll") {
+            Copy-Item "$bin\qcustomplot.dll" "$bin\qcustomplot2.dll"
+          }
+
+      - name: Build
+        shell: cmd
+        env:
+          VCPKG_DIR: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed\x64-windows
+        run: |
+          qmake wfview.pro CONFIG+=release
+          nmake release
+
+      - name: Get version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = (Select-String -Path wfview.pro -Pattern 'WFVIEW_VERSION=\\\"([\d.]+)\\\"').Matches[0].Groups[1].Value
+          echo "version=$ver" >> $env:GITHUB_OUTPUT
+
+      - name: Package zip
+        shell: pwsh
+        env:
+          VCPKG_DIR: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed\x64-windows
+        run: |
+          $dest = "wfweb-windows-x64"
+          New-Item -ItemType Directory -Force -Path $dest
+
+          # Application binary
+          Copy-Item "wfview-release\wfview.exe" $dest\
+
+          # Qt runtime DLLs
+          windeployqt "$dest\wfview.exe" --release --no-translations
+
+          # vcpkg runtime DLLs
+          Copy-Item "$env:VCPKG_DIR\bin\*.dll" $dest\ -ErrorAction SilentlyContinue
+
+          # Rig definition files
+          Copy-Item -Recurse rigs "$dest\rigs"
+
+          Compress-Archive -Path $dest -DestinationPath wfweb-windows-x64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wfweb-windows-x64
+          path: wfweb-windows-x64.zip
+          retention-days: 30
+
   release:
     name: Publish release
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -141,5 +231,6 @@ jobs:
             wfweb-arm64-tar/wfweb-arm64.tar.gz
             wfweb-x86_64-deb/*.deb
             wfweb-arm64-deb/*.deb
+            wfweb-windows-x64/wfweb-windows-x64.zip
           generate_release_notes: true
           overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches: [master, windows-build]
     tags: ['v*']
   pull_request:
     branches: [master]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,12 +169,14 @@ jobs:
 
       - name: Get QCustomPlot source
         # vcpkg's qcustomplot is built against Qt6; compile from source for Qt5 compatibility.
-        # The official GitLab repo contains only a README; download the release tarball instead.
+        # Tarball layout: qcustomplot-source/{qcustomplot.cpp,qcustomplot.h,...}
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri "https://www.qcustomplot.com/release/2.1.1/QCustomPlot-source.tar.gz" -OutFile "qcp-source.tar.gz"
-          New-Item -ItemType Directory -Force -Path "..\qcustomplot"
-          tar -xzf qcp-source.tar.gz -C ..\qcustomplot --strip-components=1
+          $qcpDir = "$(Split-Path $env:GITHUB_WORKSPACE -Parent)\qcustomplot"
+          New-Item -ItemType Directory -Force -Path $qcpDir
+          Invoke-WebRequest -Uri "https://www.qcustomplot.com/release/2.1.1/QCustomPlot-source.tar.gz" -OutFile "$qcpDir\qcp-source.tar.gz"
+          tar -xzf "$qcpDir\qcp-source.tar.gz" -C $qcpDir --strip-components=1
+          Get-ChildItem $qcpDir | Select-Object Name
 
       - name: Build
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
       - name: Install vcpkg packages
         shell: pwsh
         run: |
+          $env:VCPKG_ROOT = "C:\vcpkg"  # suppress MSVC-bundled vcpkg mismatch warning
           $triplet = "x64-windows"
           $pkgs = "opus", "portaudio", "hidapi", "openssl", "eigen3", "qcustomplot"
           foreach ($pkg in $pkgs) {
@@ -174,6 +175,10 @@ jobs:
           if (Test-Path "$bin\qcustomplot.dll") {
             Copy-Item "$bin\qcustomplot.dll" "$bin\qcustomplot2.dll"
           }
+
+      - name: List vcpkg libs (diagnostic)
+        shell: pwsh
+        run: Get-ChildItem "C:\vcpkg\installed\x64-windows\lib" | Select-Object Name | Sort-Object Name
 
       - name: Build
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
           path: C:\vcpkg\installed
           key: vcpkg-x64-windows-opus-portaudio-hidapi-openssl-eigen3-qcustomplot
           restore-keys: vcpkg-x64-windows-
+          save-always: true
 
       - name: Install vcpkg packages
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,11 +158,11 @@ jobs:
             vcpkg install "${pkg}:${triplet}"
           }
           # Alias qcustomplot → qcustomplot2 to match the lib name used in wfview.pro
-          $lib = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
+          $lib = "C:\vcpkg\installed\$triplet\lib"
           if (Test-Path "$lib\qcustomplot.lib") {
             Copy-Item "$lib\qcustomplot.lib" "$lib\qcustomplot2.lib"
           }
-          $bin = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\bin"
+          $bin = "C:\vcpkg\installed\$triplet\bin"
           if (Test-Path "$bin\qcustomplot.dll") {
             Copy-Item "$bin\qcustomplot.dll" "$bin\qcustomplot2.dll"
           }
@@ -170,7 +170,7 @@ jobs:
       - name: Build
         shell: cmd
         env:
-          VCPKG_DIR: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed\x64-windows
+          VCPKG_DIR: C:\vcpkg\installed\x64-windows
         run: |
           qmake wfview.pro CONFIG+=release
           nmake release
@@ -185,7 +185,7 @@ jobs:
       - name: Package zip
         shell: pwsh
         env:
-          VCPKG_DIR: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed\x64-windows
+          VCPKG_DIR: C:\vcpkg\installed\x64-windows
         run: |
           $dest = "wfweb-windows-x64"
           New-Item -ItemType Directory -Force -Path $dest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master, windows-build]
+    branches: [master]
     tags: ['v*']
   pull_request:
     branches: [master]

--- a/include/pttyhandler.h
+++ b/include/pttyhandler.h
@@ -2,16 +2,42 @@
 #define PTTYHANDLER_H
 
 #include <QObject>
+#include "rigidentities.h"
+#include "wfviewtypes.h"
+#include "cachingqueue.h"
+
+#ifdef Q_OS_WIN
+
+// PTY (pseudo-terminal) is a POSIX facility not available on Windows.
+// This no-op stub provides the same interface so all callers compile unchanged.
+// Virtual serial port (VSP) functionality is simply unavailable on Windows.
+class pttyHandler : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit pttyHandler(QString, QObject* parent = nullptr) : QObject(parent) {}
+    pttyHandler(QString, quint32) {}
+    ~pttyHandler() {}
+    bool serialError = false;
+
+public slots:
+    void receiveDataFromRigToPtty(const QByteArray&) {}
+
+signals:
+    void haveTextMessage(QString message);
+    void haveDataFromPort(QByteArray data);
+    void havePortError(errorType err);
+    void haveStatusUpdate(const QString text);
+};
+
+#else // Q_OS_WIN — full POSIX implementation
 
 #include <QMutex>
 #include <QDataStream>
 #include <QIODevice>
 #include <QSocketNotifier>
 #include <QtSerialPort/QSerialPort>
-
-#include "rigidentities.h"
-#include "wfviewtypes.h"
-#include "cachingqueue.h"
 
 // This class abstracts the comm port in a useful way and connects to
 // the command creator and command parser.
@@ -77,5 +103,7 @@ private:
     rigCapabilities* rigCaps = Q_NULLPTR;
     cachingQueue* queue = Q_NULLPTR;
 };
+
+#endif // Q_OS_WIN
 
 #endif // PTTYHANDLER_H

--- a/wfview.pro
+++ b/wfview.pro
@@ -310,7 +310,7 @@ win32 {
         INCLUDEPATH += $$VCPKG_DIR/include/hidapi
         LIBS += -L$$VCPKG_DIR/lib
         # portaudio, openssl — not in the sibling-dir layout; added here for vcpkg builds
-        LIBS += -lportaudio -lssl -lcrypto
+        LIBS += -lportaudio -llibssl -llibcrypto
     } else {
         INCLUDEPATH += ../opus/include
         INCLUDEPATH += ../eigen

--- a/wfview.pro
+++ b/wfview.pro
@@ -308,7 +308,10 @@ win32 {
         INCLUDEPATH += $$VCPKG_DIR/include/hidapi
         LIBS += -L$$VCPKG_DIR/lib
         LIBS += -lportaudio -llibssl -llibcrypto
-        # vcpkg qcustomplot is built against Qt6; compile from source for Qt5 compatibility
+        # vcpkg qcustomplot is built against Qt6; compile from source for Qt5 compatibility.
+        # Remove QCUSTOMPLOT_USE_LIBRARY (set unconditionally above): compiling from source
+        # means no DLL import — neither USE_LIBRARY nor COMPILE_LIBRARY should be defined.
+        DEFINES -= QCUSTOMPLOT_USE_LIBRARY
         SOURCES += ../qcustomplot/qcustomplot.cpp
         HEADERS += ../qcustomplot/qcustomplot.h
     } else {

--- a/wfview.pro
+++ b/wfview.pro
@@ -232,7 +232,7 @@ CONFIG(debug, release|debug) {
     linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotqt6.so/ {print \"-lqcustomplotqt6\"}'")
   }
   win32 {
-    VCPKG_DIR_REL = $$(VCPKG_DIR)
+    VCPKG_DIR_REL = $$VCPKG_DIR
     !isEmpty(VCPKG_DIR_REL) {
       # vcpkg build (CI): qcustomplot is compiled from source (see VCPKG_DIR block above).
       contains(DEFINES,USB_CONTROLLER) {

--- a/wfview.pro
+++ b/wfview.pro
@@ -306,6 +306,8 @@ win32 {
     !isEmpty(VCPKG_DIR) {
         INCLUDEPATH += $$VCPKG_DIR/include
         INCLUDEPATH += $$VCPKG_DIR/include/eigen3
+        INCLUDEPATH += $$VCPKG_DIR/include/opus
+        INCLUDEPATH += $$VCPKG_DIR/include/hidapi
         LIBS += -L$$VCPKG_DIR/lib
         # portaudio, openssl — not in the sibling-dir layout; added here for vcpkg builds
         LIBS += -lportaudio -lssl -lcrypto

--- a/wfview.pro
+++ b/wfview.pro
@@ -234,9 +234,7 @@ CONFIG(debug, release|debug) {
   win32 {
     VCPKG_DIR_REL = $$(VCPKG_DIR)
     !isEmpty(VCPKG_DIR_REL) {
-      # vcpkg build (CI): all deps come from the vcpkg installed tree.
-      # VCPKG_DIR is already set in the block above; lib names use vcpkg conventions.
-      LIBS += -lqcustomplot2
+      # vcpkg build (CI): qcustomplot is compiled from source (see VCPKG_DIR block above).
       contains(DEFINES,USB_CONTROLLER) {
         LIBS += -lhidapi
       }
@@ -299,18 +297,20 @@ win32:INCLUDEPATH += ../hidapi/hidapi
 #}
 
 # vcpkg integration for Windows CI builds.
-# Set VCPKG_DIR to <vcpkg_root>/installed/x64-windows before calling qmake.
-# When not set, falls back to the sibling-directory layout used by upstream wfview.
+# Pass VCPKG_DIR=C:/vcpkg/installed/x64-windows on the qmake command line, or set it
+# as an environment variable. When not set, falls back to the sibling-directory layout.
 win32 {
-    VCPKG_DIR = $$(VCPKG_DIR)
+    isEmpty(VCPKG_DIR): VCPKG_DIR = $$(VCPKG_DIR)
     !isEmpty(VCPKG_DIR) {
         INCLUDEPATH += $$VCPKG_DIR/include
         INCLUDEPATH += $$VCPKG_DIR/include/eigen3
         INCLUDEPATH += $$VCPKG_DIR/include/opus
         INCLUDEPATH += $$VCPKG_DIR/include/hidapi
         LIBS += -L$$VCPKG_DIR/lib
-        # portaudio, openssl — not in the sibling-dir layout; added here for vcpkg builds
         LIBS += -lportaudio -llibssl -llibcrypto
+        # vcpkg qcustomplot is built against Qt6; compile from source for Qt5 compatibility
+        SOURCES += ../qcustomplot/qcustomplot.cpp
+        HEADERS += ../qcustomplot/qcustomplot.h
     } else {
         INCLUDEPATH += ../opus/include
         INCLUDEPATH += ../eigen

--- a/wfview.pro
+++ b/wfview.pro
@@ -237,7 +237,7 @@ CONFIG(debug, release|debug) {
       # vcpkg build (CI): all deps come from the vcpkg installed tree.
       # VCPKG_DIR is already set in the block above; lib names use vcpkg conventions.
       LIBS += -lqcustomplot2
-      contains(DEFINES, USB_CONTROLLER) {
+      contains(DEFINES,USB_CONTROLLER) {
         LIBS += -lhidapi
       }
     } else {

--- a/wfview.pro
+++ b/wfview.pro
@@ -232,31 +232,42 @@ CONFIG(debug, release|debug) {
     linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotqt6.so/ {print \"-lqcustomplotqt6\"}'")
   }
   win32 {
-    contains(QMAKE_TARGET.arch, x86_64) {
-      LIBS += -L../opus/win32/VS2015/x64/ReleaseDLL/
-      LIBS += -L../qcustomplot/x64 -lqcustomplot2
-      LIBS += -L../portaudio/msvc/X64/Release/ -lportaudio_x64
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\LibFT4222-v1.4.8\imports\LibFT4222\dll\amd64\LibFT4222-64.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\qcustomplot\x64\qcustomplot2.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\portaudio\msvc\x64\Release\portaudio_x64.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\hidapi\windows\X64\Release\hidapi.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\opus\win32\VS2015\x64\ReleaseDLL\opus-0.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c xcopy /s/y ..\wfview\rigs\*.* wfview-release\rigs\*.* $$escape_expand(\\n\\t))
-      contains(DEFINES,USB_CONTROLLER){
-            LIBS += -L../hidapi/windows/x64/release -lhidapi
+    VCPKG_DIR_REL = $$(VCPKG_DIR)
+    !isEmpty(VCPKG_DIR_REL) {
+      # vcpkg build (CI): all deps come from the vcpkg installed tree.
+      # VCPKG_DIR is already set in the block above; lib names use vcpkg conventions.
+      LIBS += -lqcustomplot2
+      contains(DEFINES, USB_CONTROLLER) {
+        LIBS += -lhidapi
       }
     } else {
-      LIBS += -L../opus/win32/VS2015/win32/ReleaseDLL/
-      LIBS += -L../qcustomplot/win32 -lqcustomplot2
-      LIBS += -L../portaudio/msvc/Win32/Release/ -lportaudio_x86
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\LibFT4222-v1.4.8\imports\LibFT4222\dll\i386\LibFT4222.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\qcustomplot\win32\qcustomplot2.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\portaudio\msvc\win32\Release\portaudio_x86.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\hidapi\windows\Release\hidapi.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\opus\win32\VS2015\win32\ReleaseDLL\opus-0.dll wfview-release $$escape_expand(\\n\\t))
-      QMAKE_POST_LINK +=$$quote(cmd /c xcopy /s/y ..\wfview\rigs\*.* wfview-release\rigs\*.* $$escape_expand(\\n\\t))
-      contains(DEFINES,USB_CONTROLLER){
-            win32:LIBS += -L../hidapi/windows/release -lhidapi
+      # Sibling-directory layout (upstream wfview Windows dev setup).
+      contains(QMAKE_TARGET.arch, x86_64) {
+        LIBS += -L../opus/win32/VS2015/x64/ReleaseDLL/
+        LIBS += -L../qcustomplot/x64 -lqcustomplot2
+        LIBS += -L../portaudio/msvc/X64/Release/ -lportaudio_x64
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\LibFT4222-v1.4.8\imports\LibFT4222\dll\amd64\LibFT4222-64.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\qcustomplot\x64\qcustomplot2.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\portaudio\msvc\x64\Release\portaudio_x64.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\hidapi\windows\X64\Release\hidapi.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\opus\win32\VS2015\x64\ReleaseDLL\opus-0.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c xcopy /s/y ..\wfview\rigs\*.* wfview-release\rigs\*.* $$escape_expand(\\n\\t))
+        contains(DEFINES,USB_CONTROLLER){
+          LIBS += -L../hidapi/windows/x64/release -lhidapi
+        }
+      } else {
+        LIBS += -L../opus/win32/VS2015/win32/ReleaseDLL/
+        LIBS += -L../qcustomplot/win32 -lqcustomplot2
+        LIBS += -L../portaudio/msvc/Win32/Release/ -lportaudio_x86
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\LibFT4222-v1.4.8\imports\LibFT4222\dll\i386\LibFT4222.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\qcustomplot\win32\qcustomplot2.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\portaudio\msvc\win32\Release\portaudio_x86.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\hidapi\windows\Release\hidapi.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c copy /y ..\opus\win32\VS2015\win32\ReleaseDLL\opus-0.dll wfview-release $$escape_expand(\\n\\t))
+        QMAKE_POST_LINK +=$$quote(cmd /c xcopy /s/y ..\wfview\rigs\*.* wfview-release\rigs\*.* $$escape_expand(\\n\\t))
+        contains(DEFINES,USB_CONTROLLER){
+          LIBS += -L../hidapi/windows/release -lhidapi
+        }
       }
     }
   }
@@ -287,9 +298,28 @@ win32:INCLUDEPATH += ../hidapi/hidapi
 #  win32:INCLUDEPATH += ../LibFT4222-v1.4.7\imports\ftd2xx
 #}
 
-!linux:INCLUDEPATH += ../opus/include
-!linux:INCLUDEPATH += ../eigen
-!linux:INCLUDEPATH += ../r8brain-free-src
+# vcpkg integration for Windows CI builds.
+# Set VCPKG_DIR to <vcpkg_root>/installed/x64-windows before calling qmake.
+# When not set, falls back to the sibling-directory layout used by upstream wfview.
+win32 {
+    VCPKG_DIR = $$(VCPKG_DIR)
+    !isEmpty(VCPKG_DIR) {
+        INCLUDEPATH += $$VCPKG_DIR/include
+        INCLUDEPATH += $$VCPKG_DIR/include/eigen3
+        LIBS += -L$$VCPKG_DIR/lib
+        # portaudio, openssl — not in the sibling-dir layout; added here for vcpkg builds
+        LIBS += -lportaudio -lssl -lcrypto
+    } else {
+        INCLUDEPATH += ../opus/include
+        INCLUDEPATH += ../eigen
+        INCLUDEPATH += ../r8brain-free-src
+    }
+}
+macx {
+    INCLUDEPATH += ../opus/include
+    INCLUDEPATH += ../eigen
+    INCLUDEPATH += ../r8brain-free-src
+}
 
 INCLUDEPATH += include
 INCLUDEPATH += src/audio
@@ -332,7 +362,8 @@ SOURCES += \
     src/main.cpp \
     src/memories.cpp \
     src/meter.cpp \
-    src/pttyhandler.cpp \
+    # src/pttyhandler.cpp — excluded on Windows (POSIX PTY); see !win32 block below
+
     src/qledlabel.cpp \
     src/radio/icomcommander.cpp \
     src/radio/icomserver.cpp \
@@ -368,6 +399,10 @@ SOURCES += \
     src/usbcontroller.cpp \
     src/webserver.cpp \
     src/wfmain.cpp
+
+# PTY is a POSIX facility — exclude the implementation on Windows.
+# The header provides a no-op stub so callers compile unchanged.
+!win32:SOURCES += src/pttyhandler.cpp
 
 HEADERS  += \
     src/audio/adpcm/adpcm-lib.h \

--- a/wfview.pro
+++ b/wfview.pro
@@ -362,8 +362,6 @@ SOURCES += \
     src/main.cpp \
     src/memories.cpp \
     src/meter.cpp \
-    # src/pttyhandler.cpp — excluded on Windows (POSIX PTY); see !win32 block below
-
     src/qledlabel.cpp \
     src/radio/icomcommander.cpp \
     src/radio/icomserver.cpp \


### PR DESCRIPTION
  Adds the groundwork for building wfweb on Windows x64 via GitHub Actions CI:

  - pttyhandler.h: #ifdef Q_OS_WIN no-op stub — PTY is a POSIX facility unavailable on Windows; all callers
  compile unchanged
  - wfview.pro: exclude pttyhandler.cpp on Windows; add vcpkg-aware dependency block (activated via VCPKG_DIR env
  var) for include paths, portaudio, and OpenSSL; restructure the release win32 lib block to use vcpkg when
  available, falling back to the upstream sibling-directory layout for local Windows dev
  - build.yml: new build-windows job — Qt 5.15.2 MSVC 2019 x64, RTAudio compiled from source, deps installed via
  vcpkg (opus, portaudio, hidapi, openssl, eigen3, qcustomplot), qmake + nmake, vcpkg package cache, windeployqt
  packaging, zip artifact upload; release job updated to include the Windows zip

  This is a first pass — compile errors are expected and will be iterated on via CI feedback.