### PR TITLE
Checking for EooDraining only if compiling with RADE_SUPPORT

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -2983,6 +2983,7 @@ void webServer::drainFreeDVTxBuffer()
         chunk.append(QByteArray(chunkSize - chunk.size(), 0));
         usbAudioOutputDevice->write(chunk);
         freedvTxBuffer.clear();
+#ifdef RADE_SUPPORT
     } else if (radeEooDraining) {
         // EOO frame fully drained — stop ALSA and clean up TX state
         radeEooDraining = false;
@@ -2995,6 +2996,7 @@ void webServer::drainFreeDVTxBuffer()
         }
         qInfo() << "Web: RADE EOO drain complete, ALSA stopped";
         return;
+#endif
     } else {
         // No data: write silence to keep ALSA fed
         QByteArray silence(chunkSize, 0);


### PR DESCRIPTION
As `radeEooDraining` is only added to `webserver.h` if `RADE_SUPPORT` is enabled, this check should also be exluded to avoid the error below

```cpp
src/webserver.cpp: In member function ‘void webServer::drainFreeDVTxBuffer()’:
src/webserver.cpp:2986:16: error: ‘radeEooDraining’ was not declared in this scope
 2986 |     } else if (radeEooDraining) {
      |                ^~~~~~~~~~~~~~~
```