### PR TITLE
Fix CW decoder audio cracking on Windows browsers

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -78,6 +78,18 @@ Note: `opus` is **not** installed via vcpkg. A custom Opus build with DRED/OSCE
 extensions is compiled from the `radae_nopy` submodule and statically linked for
 RADE support.
 
+### Clone
+
+```
+git clone --recursive https://github.com/adecarolis/wfweb.git
+```
+
+If you already cloned without `--recursive`:
+
+```
+git submodule update --init
+```
+
 #### Sibling repositories
 
 Clone `rtaudio` alongside `wfweb/`:
@@ -111,7 +123,7 @@ All build output goes to `build.log`. The last line is `EXIT:0` (success) or `EX
 1. **RADE custom Opus** (if `radae_nopy` submodule is present):
    - Runs `cmake` + `make` inside MSYS2 to fetch and build the custom Opus
      source (with LPCNet/FARGAN) via CMake ExternalProject.
-   - Patches Opus and RADE headers for MSVC compatibility (`sed` in MSYS2).
+   - Patches Opus and RADE headers for MSVC compatibility (PowerShell).
    - Builds the custom Opus as a static `.lib` using MSVC cmake.
    - Skipped if `resources/radae_nopy/build/opus_msvc_build/Release/opus.lib` already exists.
 
@@ -155,8 +167,24 @@ These are called by `build.bat` and are not intended to be run manually:
 
 | Script | Purpose |
 |---|---|
-| `build-rade-opus.sh` | MSYS2: cmake build of RADE custom Opus + header patching |
+| `build-rade-opus.sh` | MSYS2: cmake build of RADE custom Opus |
 | `build-codec2.sh` | MSYS2 MinGW: build codec2 as a DLL, install headers |
+
+### Troubleshooting
+
+**RADE build fails immediately**: If the RADE MSYS2 cmake step fails with
+`ninja: error: bad $-escape`, delete `resources/radae_nopy/build/` and rebuild.
+The `build-rade-opus.sh` script forces the "Unix Makefiles" cmake generator to
+avoid this issue.
+
+**RADE MSVC build fails with `RADE_EXPORT` errors**: The header patching step
+may have been skipped. Delete `resources/radae_nopy/build/opus_msvc_build/` and
+rebuild — the patching step runs independently of the MSYS2 build and will
+re-apply the patches.
+
+**Full RADE rebuild**: Delete the entire `resources/radae_nopy/build/` directory.
+The next build will redo the MSYS2 cmake, header patching, and MSVC build from
+scratch.
 
 ## macOS
 

--- a/build-rade-opus.sh
+++ b/build-rade-opus.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
-# Build RADE custom Opus via MSYS2, then patch headers for MSVC. (called from build.bat)
+# Build RADE custom Opus via MSYS2. (called from build.bat)
 set -e
 pacman -S --noconfirm --needed autoconf automake libtool make patch gcc cmake > /dev/null 2>&1
 RADAE_DIR="$(cygpath "$1")"
 cd "$RADAE_DIR"
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
 make -j$(nproc)
-
-# Patch Opus nnet.h: add _MSC_VER guard for RADE_EXPORT
-NNET_H="build_opus-prefix/src/build_opus/dnn/nnet.h"
-if [ -f "$NNET_H" ] && ! grep -q '_MSC_VER' "$NNET_H"; then
-    sed -i 's|#define RADE_EXPORT __attribute__((visibility("default")))|#ifdef _MSC_VER\n    #define RADE_EXPORT\n  #else\n    #define RADE_EXPORT __attribute__((visibility("default")))\n  #endif|' "$NNET_H"
-    echo "Patched $NNET_H"
-fi
-
-# Patch rade_api.h: add RADE_STATIC guard
-RADE_API_H="$RADAE_DIR/src/rade_api.h"
-if [ -f "$RADE_API_H" ] && ! grep -q 'RADE_STATIC' "$RADE_API_H"; then
-    sed -i 's|#if IS_BUILDING_RADE_API|#if defined(RADE_STATIC)\n#define RADE_EXPORT\n#elif IS_BUILDING_RADE_API|' "$RADE_API_H"
-    echo "Patched $RADE_API_H"
-fi

--- a/build.bat
+++ b/build.bat
@@ -69,9 +69,9 @@ if exist "%RADAE_DIR%\src\rade_api.h" (
     if not exist "%OPUS_MSVC_LIB%" (
         echo === RADE: building custom Opus === >> %LOG%
 
-        :: Step 1: MSYS2 cmake to fetch/build Opus source + patch headers for MSVC
+        :: Step 1: MSYS2 cmake to fetch/build Opus source
         if not exist "%RADAE_BUILD%\build_opus-prefix\src\build_opus\include\opus.h" (
-            echo --- MSYS2 cmake + header patching --- >> %LOG%
+            echo --- MSYS2 cmake build --- >> %LOG%
             C:\msys64\usr\bin\bash.exe -l "%SRCDIR%\build-rade-opus.sh" "%RADAE_DIR%" >> %LOG% 2>&1
             if errorlevel 1 (
                 echo ERROR: MSYS2 RADE build failed >> %LOG%
@@ -80,7 +80,11 @@ if exist "%RADAE_DIR%\src\rade_api.h" (
             )
         )
 
-        :: Step 2: Build custom Opus with MSVC (static lib)
+        :: Step 2: Patch Opus/RADE headers for MSVC (idempotent)
+        echo --- Patching headers for MSVC --- >> %LOG%
+        call :patch_rade_headers
+
+        :: Step 3: Build custom Opus with MSVC (static lib)
         echo --- MSVC Opus build --- >> %LOG%
         set OPUS_SRC=%RADAE_BUILD%\build_opus-prefix\src\build_opus
         cmake -S "!OPUS_SRC!" -B "%RADAE_BUILD%\opus_msvc_build" -DOPUS_DRED=ON -DOPUS_OSCE=ON -DBUILD_SHARED_LIBS=OFF -DOPUS_BUILD_PROGRAMS=OFF -DOPUS_BUILD_TESTING=OFF -A x64 >> %LOG% 2>&1
@@ -202,3 +206,17 @@ echo Rig files deployed >> %LOG%
 echo BUILD OK: wfweb-release\wfweb.exe >> %LOG%
 echo EXIT:0 >> %LOG%
 exit /b 0
+
+:: ---------------------------------------------------------------
+:: Subroutines (must be after exit /b to avoid falling through)
+:: ---------------------------------------------------------------
+
+:patch_rade_headers
+:: Patch Opus nnet.h and rade_api.h for MSVC compatibility.
+:: Uses PowerShell to avoid parenthesis-escaping issues in cmd.exe if-blocks.
+:: Idempotent — skips files already patched.
+set NNET_H=%RADAE_BUILD%\build_opus-prefix\src\build_opus\dnn\nnet.h
+set RADE_API_H=%RADAE_DIR%\src\rade_api.h
+powershell -NoProfile -Command "$nnet = '%NNET_H%'; if (Test-Path $nnet) { $c = Get-Content $nnet -Raw; if ($c -match '#define RADE_EXPORT __attribute__') { $c = $c -replace '#define RADE_EXPORT __attribute__\(\(visibility\(\"default\"\)\)\)', \"#ifdef _MSC_VER`n    #define RADE_EXPORT`n  #else`n    #define RADE_EXPORT __attribute__((visibility(\"\"default\"\")))  `n  #endif\"; Set-Content $nnet $c -NoNewline; 'Patched nnet.h' } else { 'nnet.h already patched' } }" >> %LOG% 2>&1
+powershell -NoProfile -Command "$api = '%RADE_API_H%'; if (Test-Path $api) { $c = Get-Content $api -Raw; if ($c -notmatch 'RADE_STATIC') { $c = $c -replace '#if IS_BUILDING_RADE_API', \"#if defined(RADE_STATIC)`n#define RADE_EXPORT`n#elif IS_BUILDING_RADE_API\"; Set-Content $api $c -NoNewline; 'Patched rade_api.h' } else { 'rade_api.h already patched' } }" >> %LOG% 2>&1
+goto :eof

--- a/resources/web/cw-decoder.js
+++ b/resources/web/cw-decoder.js
@@ -43,6 +43,8 @@
     let audioContext = null;
     let decoderWorker = null;
     let rafId = null;
+    let cwWorkletLoaded = false;
+    let cwUseWorklet = false;
 
     // Audio buffer for inference - sliding window like demo
     const audioBuffer = new Float32Array(BUFFER_SAMPLES);
@@ -59,6 +61,43 @@
 
     // Color LUT
     let colorLUT = null;
+
+    // AudioWorklet processor: runs decimation on the audio thread to avoid main-thread jitter
+    // that causes audio cracking on Windows (see issue #21)
+    const CW_PROCESSOR_CODE = [
+        'class CWDecoderProcessor extends AudioWorkletProcessor {',
+        '  constructor(options) {',
+        '    super();',
+        '    var targetRate = (options.processorOptions && options.processorOptions.targetRate) || 4000;',
+        '    this.df = Math.max(1, Math.round(sampleRate / targetRate));',
+        '    this.acc = 0;',
+        '    this.cnt = 0;',
+        '    this.outBuf = new Float32Array(Math.ceil(128 / this.df) + 1);',
+        '  }',
+        '  process(inputs, outputs) {',
+        '    var input = inputs[0] && inputs[0][0];',
+        '    var output = outputs[0] && outputs[0][0];',
+        '    if (!input || input.length === 0) { if (output) output.fill(0); return true; }',
+        '    if (output) output.set(input);',
+        '    var df = this.df, outIdx = 0;',
+        '    for (var i = 0; i < input.length; i++) {',
+        '      this.acc += input[i];',
+        '      this.cnt++;',
+        '      if (this.cnt >= df) {',
+        '        this.outBuf[outIdx++] = this.acc / df;',
+        '        this.acc = 0;',
+        '        this.cnt = 0;',
+        '      }',
+        '    }',
+        '    if (outIdx > 0) {',
+        '      var arr = this.outBuf.slice(0, outIdx);',
+        '      this.port.postMessage(arr, [arr.buffer]);',
+        '    }',
+        '    return true;',
+        '  }',
+        '}',
+        'registerProcessor("cw-decoder-processor", CWDecoderProcessor);'
+    ].join('\n');
 
     // Initialize
     function init() {
@@ -270,41 +309,43 @@
             gainNode = audioContext.createGain();
             gainNode.gain.value = Math.pow(10, decoderState.gain / 20);
 
-            // ScriptProcessor for audio capture (like demo's useAudioProcessing)
-            processorNode = audioContext.createScriptProcessor(2048, 1, 1);
-            processorNode.onaudioprocess = (e) => {
-                const inputData = e.inputBuffer.getChannelData(0);
-                const outputData = e.outputBuffer.getChannelData(0);
-                outputData.set(inputData);  // Pass-through
-
-                if (!decoderState.enabled) return;
-
-                // Sliding window: copyWithin + set (exactly like demo)
-                const chunkLen = inputData.length;
-                const sourceRate = audioContext.sampleRate;  // 48000
-                const decimationFactor = Math.round(sourceRate / SAMPLE_RATE);  // 15
-                const samplesToProduce = Math.floor(chunkLen / decimationFactor);
-
-                // Simple decimation (no gain here - gain is applied via gainNode)
-                const resampledChunk = new Float32Array(samplesToProduce);
-
-                for (let i = 0; i < samplesToProduce; i++) {
-                    let sum = 0;
-                    const startIdx = i * decimationFactor;
-                    for (let j = 0; j < decimationFactor; j++) {
-                        sum += inputData[startIdx + j];
+            // Audio capture: prefer AudioWorklet (decimation on audio thread, no
+            // main-thread jitter) with ScriptProcessor fallback for non-secure contexts
+            if (audioContext.audioWorklet && window.isSecureContext) {
+                try {
+                    if (!cwWorkletLoaded) {
+                        const blob = new Blob([CW_PROCESSOR_CODE], { type: 'application/javascript' });
+                        const url = URL.createObjectURL(blob);
+                        await audioContext.audioWorklet.addModule(url);
+                        URL.revokeObjectURL(url);
+                        cwWorkletLoaded = true;
                     }
-                    resampledChunk[i] = sum / decimationFactor;
+
+                    processorNode = new AudioWorkletNode(audioContext, 'cw-decoder-processor', {
+                        numberOfInputs: 1,
+                        numberOfOutputs: 1,
+                        outputChannelCount: [1],
+                        processorOptions: { targetRate: SAMPLE_RATE }
+                    });
+
+                    processorNode.port.onmessage = (e) => {
+                        if (!decoderState.enabled) return;
+                        const resampledChunk = e.data;
+                        const resampledLen = resampledChunk.length;
+                        audioBuffer.copyWithin(0, resampledLen);
+                        audioBuffer.set(resampledChunk, BUFFER_SAMPLES - resampledLen);
+                        totalSamplesAccumulated += resampledLen;
+                    };
+
+                    cwUseWorklet = true;
+                    console.log('[CW Decoder] Using AudioWorklet processor');
+                } catch (err) {
+                    console.warn('[CW Decoder] AudioWorklet failed, falling back to ScriptProcessor:', err);
+                    createCWScriptProcessor();
                 }
-
-                // Sliding window (exactly like demo)
-                const resampledLen = resampledChunk.length;
-                audioBuffer.copyWithin(0, resampledLen);
-                audioBuffer.set(resampledChunk, BUFFER_SAMPLES - resampledLen);
-
-                // Track how many new samples have arrived
-                totalSamplesAccumulated += resampledLen;
-            };
+            } else {
+                createCWScriptProcessor();
+            }
 
             // Connect nodes
             connectAudioNodes();
@@ -338,6 +379,39 @@
             decoderState.loading = false;
             updateButtons();
         }
+    }
+
+    function createCWScriptProcessor() {
+        processorNode = audioContext.createScriptProcessor(2048, 1, 1);
+        processorNode.onaudioprocess = (e) => {
+            const inputData = e.inputBuffer.getChannelData(0);
+            const outputData = e.outputBuffer.getChannelData(0);
+            outputData.set(inputData);  // Pass-through
+
+            if (!decoderState.enabled) return;
+
+            const chunkLen = inputData.length;
+            const sourceRate = audioContext.sampleRate;
+            const decimationFactor = Math.round(sourceRate / SAMPLE_RATE);
+            const samplesToProduce = Math.floor(chunkLen / decimationFactor);
+            const resampledChunk = new Float32Array(samplesToProduce);
+
+            for (let i = 0; i < samplesToProduce; i++) {
+                let sum = 0;
+                const startIdx = i * decimationFactor;
+                for (let j = 0; j < decimationFactor; j++) {
+                    sum += inputData[startIdx + j];
+                }
+                resampledChunk[i] = sum / decimationFactor;
+            }
+
+            const resampledLen = resampledChunk.length;
+            audioBuffer.copyWithin(0, resampledLen);
+            audioBuffer.set(resampledChunk, BUFFER_SAMPLES - resampledLen);
+            totalSamplesAccumulated += resampledLen;
+        };
+        cwUseWorklet = false;
+        console.log('[CW Decoder] Using ScriptProcessor fallback');
     }
 
     function connectAudioNodes() {
@@ -382,6 +456,7 @@
 
         if (processorNode) {
             processorNode.disconnect();
+            if (processorNode.port) processorNode.port.onmessage = null;
             processorNode.onaudioprocess = null;
             processorNode = null;
         }


### PR DESCRIPTION
## Summary
- Replaces deprecated `ScriptProcessorNode` with `AudioWorkletNode` for CW decoder audio capture
- The old ScriptProcessor ran decimation on the main thread, causing contention with spectrogram rendering and audible clicks (especially on Windows with WASAPI scheduling jitter)
- New AudioWorklet runs decimation on a dedicated real-time audio thread; falls back to ScriptProcessor on non-secure (HTTP) contexts

## Test plan
- [x] Confirmed fixed by issue reporter (otti-soft) on Windows: "works like a charm, no more clicking at all with CW decoder enabled"

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)