### PR TITLE
Fix UI elements not populated after LAN power-up (#19)

### DIFF
--- a/include/icomcommander.h
+++ b/include/icomcommander.h
@@ -133,6 +133,7 @@ private:
     bool warnedAboutFA=false;
     int consecutiveFAErrors=0;
     int validResponseCount=0;
+    QElapsedTimer powerOnTime;  // tracks when rigPoweredOn last became true
     double frequencyMhz;
     quint16 civAddr;
     quint16 incomingCIVAddr; // place to store the incoming CIV.

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -2680,6 +2680,10 @@ function handleMessage(msg) {
             if (msg.hasPowerControl) document.getElementById('powerBtn').style.display = 'flex';
             if (msg.freedvModes) freedvModes = msg.freedvModes;
             updateWarningVisibility();
+            // After rig identification, request a full status refresh so
+            // UI elements populate even if the browser connected before
+            // the radio was identified (LAN power-up scenario, issue #19).
+            setTimeout(function() { send({ cmd: 'getStatus' }); }, 1500);
             break;
         case 'audioAvailable':
             if (msg.available) { audioAvailable = true; audioSampleRate = msg.sampleRate || 48000; }

--- a/src/radio/icomcommander.cpp
+++ b/src/radio/icomcommander.cpp
@@ -636,6 +636,7 @@ void icomCommander::parseData(QByteArray dataInput)
                     qInfo(logRig()) << "Sustained valid responses — radio powered on";
                     queue->receiveValue(funcPowerControl,QVariant::fromValue<bool>(true),0);
                     rigPoweredOn = true;
+                    powerOnTime.start();
                     validResponseCount = 0;
                 }
 
@@ -649,7 +650,10 @@ void icomCommander::parseData(QByteArray dataInput)
                     // The data are "to 00" and "from E1"
                     // Don't use it!
                     // We can use this to indicate power status I think.
-                    if (rigPoweredOn) {
+                    // Suppress echo-based power-off for 5 seconds after power-on
+                    // to avoid oscillation from delayed broadcast echoes
+                    // during LAN boot-up (issue #19).
+                    if (rigPoweredOn && (!powerOnTime.isValid() || powerOnTime.elapsed() > 5000)) {
                         qDebug(logRig()) << "Echo caught:" << data.toHex(' ');
                         queue->message("Radio is available but may be powered-off");
                         queue->receiveValue(funcPowerControl,QVariant::fromValue<bool>(false),0);


### PR DESCRIPTION
Two issues compound during LAN power-up: (1) the browser connects before the rig is identified, so sendCurrentState() returns empty data, and new cache entries don't emit cacheUpdated; (2) delayed broadcast echoes in the CI-V echo handler trigger false power-off, clearing the queue.

Fix by requesting a full status refresh 1.5s after rigConnected arrives in the browser, and suppressing echo-based power-off for 5s after power-on detection.