### PR TITLE
Add LAN disconnect/reconnect UI and clean shutdown (#17)

### DIFF
--- a/include/servermain.h
+++ b/include/servermain.h
@@ -189,6 +189,8 @@ signals:
 public slots:
     void powerRigOff();
     void powerRigOn();
+    void disconnectLan();
+    void reconnectLan();
 
 private slots:
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -75,6 +75,8 @@ signals:
     void closed();
     void requestPowerOn();
     void requestPowerOff();
+    void requestLanDisconnect();
+    void requestLanReconnect();
     void setupConverter(QAudioFormat inFormat, codecType inCodec,
                         QAudioFormat outFormat, codecType outCodec,
                         quint8 opusComplexity, quint8 resampleQuality);
@@ -101,6 +103,7 @@ public slots:
     void receiveRxAudio(audioPacket audio);
     void setupAudio(quint8 codec, quint32 sampleRate);
     void setupUsbAudio(quint32 sampleRate);
+    void setLanInfo(bool isLan, bool connected);
 private slots:
     // HTTP
     void onHttpConnection();
@@ -182,6 +185,8 @@ private:
     QTimer *statusTimer = nullptr;
     QMimeDatabase mimeDb;
     bool rigPoweredOn = true;
+    bool lanMode = false;
+    bool lanConnected = false;
 
     // SSL
     bool sslEnabled = false;

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -1956,8 +1956,9 @@ body.digi-open .digi-bar {
         <div style="font-size: 36px; font-weight: bold; color: #0aa; margin-bottom: 6px; text-shadow: 0 0 20px rgba(0,170,170,0.4);">wfweb</div>
         <div id="powerOffModel" style="font-size: 14px; color: #888; margin-bottom: 24px;"></div>
         <div id="powerOffMsg" style="font-size: 16px; color: #777; margin-bottom: 28px;">Radio is powered off</div>
-        <div id="powerOffBtns">
-            <button onclick="doPowerOn()" style="padding: 14px 44px; font-size: 18px; font-weight: bold; color: #000; background: linear-gradient(135deg, #0c0 0%, #0a0 100%); border: none; border-radius: 8px; cursor: pointer; box-shadow: 0 4px 15px rgba(0,170,0,0.4); transition: all 0.3s ease;" onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 6px 20px rgba(0,170,0,0.6)';" onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='0 4px 15px rgba(0,170,0,0.4)';">Power On</button>
+        <div id="powerOffBtns" style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
+            <button id="powerOnBtn" onclick="doPowerOn()" style="padding: 14px 44px; font-size: 18px; font-weight: bold; color: #000; background: linear-gradient(135deg, #0c0 0%, #0a0 100%); border: none; border-radius: 8px; cursor: pointer; box-shadow: 0 4px 15px rgba(0,170,0,0.4); transition: all 0.3s ease;" onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 6px 20px rgba(0,170,0,0.6)';" onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='0 4px 15px rgba(0,170,0,0.4)';">Power On</button>
+            <button id="lanConnBtn" onclick="toggleLanConnection()" style="display: none; padding: 14px 32px; font-size: 18px; font-weight: bold; color: #fff; background: linear-gradient(135deg, #266 0%, #155 100%); border: none; border-radius: 8px; cursor: pointer; box-shadow: 0 4px 15px rgba(0,60,80,0.4); transition: all 0.3s ease;" onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 6px 20px rgba(0,60,80,0.6)';" onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='0 4px 15px rgba(0,60,80,0.4)';">Disconnect LAN</button>
         </div>
     </div>
     <div style="position: absolute; bottom: 20px; left: 20px; font-size: 11px; color: #555;">
@@ -2385,6 +2386,8 @@ var tuneStep = 1000;
 var isTransmitting = false;
 var isSplit = false;
 var rigPoweredOn = true;
+var isLan = false;
+var lanConnected = false;
 var reconnectTimer = null;
 var defaultModes = ['LSB', 'USB', 'AM', 'CW', 'RTTY', 'FM', 'CW-R'];
 
@@ -2660,6 +2663,9 @@ function handleMessage(msg) {
             }
             if (msg.model) rigModelName = msg.model;
             if (msg.freedvModes) freedvModes = msg.freedvModes;
+            if (msg.isLan !== undefined || msg.lanConnected !== undefined) {
+                updateLanStatus(!!msg.isLan, msg.lanConnected !== undefined ? !!msg.lanConnected : lanConnected);
+            }
             if (msg.connected) {
                 if (msg.modes) populateModes(msg.modes);
                 if (msg.hasSpectrum) { hasSpectrum = true; spectAmpMax = msg.spectAmpMax || 160; }
@@ -2740,9 +2746,16 @@ function handleMessage(msg) {
             if (msg.pbtOuter !== undefined) updateSlider('pbtOuter', msg.pbtOuter);
             if (msg.filterShape !== undefined) updateFilterShapeBtn(msg.filterShape);
             if (msg.powerState !== undefined) updatePowerState(msg.powerState);
+            if (msg.isLan !== undefined || msg.lanConnected !== undefined) {
+                updateLanStatus(msg.isLan !== undefined ? !!msg.isLan : isLan,
+                                msg.lanConnected !== undefined ? !!msg.lanConnected : lanConnected);
+            }
             if (msg.freedv !== undefined) updateFreeDVStatus(msg);
             if (msg.reporterEnabled !== undefined) { reporterEnabled = msg.reporterEnabled; var rcb = document.getElementById('digiReporterEnable'); if (rcb) rcb.checked = reporterEnabled; }
             if (msg.reporterState !== undefined) reporterState = msg.reporterState;
+            break;
+        case 'lanStatus':
+            updateLanStatus(!!msg.isLan, !!msg.lanConnected);
             break;
         case 'update':
             applyVfoFreqMessage(msg);
@@ -4292,6 +4305,55 @@ function updatePowerState(on) {
             audioWasEnabled = true;
             stopAudio();
         }
+    }
+    refreshPowerOffButtons();
+}
+
+function updateLanStatus(il, conn) {
+    var wasConnected = lanConnected;
+    isLan = il;
+    lanConnected = conn;
+    if (isLan && !lanConnected) {
+        // Disconnected from the radio — show the off-screen overlay so the
+        // user can reach the Connect button regardless of power state.
+        var overlay = document.getElementById('powerOffOverlay');
+        if (overlay) overlay.classList.add('visible');
+        if (audioEnabled) { audioWasEnabled = true; stopAudio(); }
+    } else if (isLan && !wasConnected && lanConnected && rigPoweredOn) {
+        // Reconnected while radio is on — hide overlay
+        var overlay = document.getElementById('powerOffOverlay');
+        if (overlay) overlay.classList.remove('visible');
+    }
+    refreshPowerOffButtons();
+}
+
+function refreshPowerOffButtons() {
+    var pOnBtn = document.getElementById('powerOnBtn');
+    var lanBtn = document.getElementById('lanConnBtn');
+    var msg = document.getElementById('powerOffMsg');
+    if (!pOnBtn || !lanBtn) return;
+    if (!isLan) {
+        lanBtn.style.display = 'none';
+        pOnBtn.style.display = '';
+        return;
+    }
+    lanBtn.style.display = '';
+    if (lanConnected) {
+        lanBtn.textContent = 'Disconnect LAN';
+        pOnBtn.style.display = '';
+        if (msg && !rigPoweredOn) msg.textContent = 'Radio is powered off';
+    } else {
+        lanBtn.textContent = 'Connect LAN';
+        pOnBtn.style.display = 'none';
+        if (msg) msg.textContent = 'Disconnected from radio';
+    }
+}
+
+function toggleLanConnection() {
+    if (lanConnected) {
+        send({ cmd: 'disconnectLan' });
+    } else {
+        send({ cmd: 'reconnectLan' });
     }
 }
 // ============================================================

--- a/src/radio/icomcommander.cpp
+++ b/src/radio/icomcommander.cpp
@@ -188,8 +188,14 @@ void icomCommander::closeComm()
     comm = Q_NULLPTR;
 
     if (udpHandlerThread != Q_NULLPTR) {
+        // When the thread finishes, the queued deleteLater posted via
+        // connect(udpHandlerThread, finished, udp, deleteLater) is
+        // processed on the UDP thread — so ~icomUdpBase() runs there and
+        // sends the 0x05 disconnect packet via its QUdpSocket.
         udpHandlerThread->quit();
         udpHandlerThread->wait();
+        delete udpHandlerThread; // avoid leaking QThread objects on reconnect
+        udpHandlerThread = Q_NULLPTR;
     }
     udp = Q_NULLPTR;
 
@@ -220,7 +226,9 @@ void icomCommander::commonSetup()
     rigCaps.commands.insert(funcPowerControl,funcType(funcPowerControl, QString("Power Control"),QByteArrayLiteral("\x18"),0,0,false,false,true,false,1,false));
     rigCaps.commandsReverse.insert(QByteArrayLiteral("\x18"),funcPowerControl);
 
-    connect(queue,SIGNAL(haveCommand(funcs,QVariant,uchar)),this,SLOT(receiveCommand(funcs,QVariant,uchar)));
+    // UniqueConnection so reconnects (closeComm → commSetup → commonSetup)
+    // don't stack duplicate connections that would fire receiveCommand twice.
+    connect(queue,SIGNAL(haveCommand(funcs,QVariant,uchar)),this,SLOT(receiveCommand(funcs,QVariant,uchar)),Qt::UniqueConnection);
     oldScopeMode = 0xff;
 
     pttAllowed = true; // This is for developing, set to false for "safe" debugging. Set to true for deployment.

--- a/src/radio/icomcommander.cpp
+++ b/src/radio/icomcommander.cpp
@@ -182,6 +182,13 @@ void icomCommander::commSetup(QHash<quint16,rigInfo> rigList, quint16 rigCivAddr
 void icomCommander::closeComm()
 {
     qDebug(logRig()) << "Closing rig comms";
+    // Clear the queue's rigCaps pointer so that when determineRigCaps()
+    // runs again on reconnect its setRigCaps(&rigCaps) call actually
+    // re-emits rigCapsUpdated — the signal is guarded by a pointer-equality
+    // check that would otherwise suppress the reconnect notification.
+    if (queue != Q_NULLPTR) {
+        queue->setRigCaps(Q_NULLPTR);
+    }
     if (comm != Q_NULLPTR) {
         delete comm;
     }
@@ -216,6 +223,12 @@ void icomCommander::commonSetup()
 
     lookingForRig = true;
     foundRig = false;
+
+    // Reconnect path: without resetting these, determineRigCaps() is skipped
+    // (gated on modelID == 0), leaving rigCaps.commands nearly empty so every
+    // incoming CI-V response logs "Unsupported command received from rig".
+    rigCaps.modelID = 0;
+    haveRigCaps = false;
 
     // Add the below commands so we can get a response until we have received rigCaps
     rigCaps.commands.clear();

--- a/src/servermain.cpp
+++ b/src/servermain.cpp
@@ -349,6 +349,11 @@ void servermain::receiveRigCaps(rigCapabilities* rigCaps)
     // Entry point for unknown rig being identified at the start of the program.
     //now we know what the rig ID is:
 
+    // closeComm() clears the queue's rigCaps pointer during LAN teardown,
+    // which emits rigCapsUpdated(nullptr). Ignore that — the reconnect
+    // will re-fire with a valid pointer after determineRigCaps() runs.
+    if (rigCaps == Q_NULLPTR) return;
+
     // Signal may come from rigCommander or cachingQueue
     rigCommander* sender = qobject_cast<rigCommander*>(QObject::sender());
 

--- a/src/servermain.cpp
+++ b/src/servermain.cpp
@@ -90,6 +90,8 @@ servermain::servermain(const QString settingsFile, const cmdLineOverrides& overr
         connect(webThread, SIGNAL(finished()), web, SLOT(deleteLater()));
         connect(web, &webServer::requestPowerOn, this, &servermain::powerRigOn);
         connect(web, &webServer::requestPowerOff, this, &servermain::powerRigOff);
+        connect(web, &webServer::requestLanDisconnect, this, &servermain::disconnectLan);
+        connect(web, &webServer::requestLanReconnect, this, &servermain::reconnectLan);
         webThread->start();
         QMetaObject::invokeMethod(web, "init", Qt::QueuedConnection,
             Q_ARG(quint16, effectiveWebPort), Q_ARG(quint16, effectiveWebPort + 1));
@@ -97,6 +99,11 @@ servermain::servermain(const QString settingsFile, const cmdLineOverrides& overr
     }
 
     openRig();
+
+    if (web != Q_NULLPTR) {
+        QMetaObject::invokeMethod(web, "setLanInfo", Qt::QueuedConnection,
+            Q_ARG(bool, prefs.enableLAN), Q_ARG(bool, prefs.enableLAN));
+    }
 
     setServerToPrefs();
 
@@ -115,6 +122,12 @@ servermain::~servermain()
     }
     for (RIGCONFIG* radio : serverConfig.rigs)
     {
+        if (radio->rig != Q_NULLPTR && radio->rigThread != Q_NULLPTR && radio->rigThread->isRunning())
+        {
+            // Synchronously close comms so ~icomUdpBase() runs and sends
+            // the 0x05 disconnect packet, releasing the radio's LAN slot.
+            QMetaObject::invokeMethod(radio->rig, "closeComm", Qt::BlockingQueuedConnection);
+        }
         if (radio->rigThread != Q_NULLPTR)
         {
             radio->rigThread->quit();
@@ -1015,6 +1028,38 @@ void servermain::initPeriodicPolling()
             qInfo(logSystem()) << "Periodic polling restored for" << rigCaps->modelName;
             break; // Only one rig supported currently
         }
+    }
+}
+
+void servermain::disconnectLan()
+{
+    if (!prefs.enableLAN) return;
+    qInfo(logSystem()) << "disconnectLan() closing rig LAN session";
+    // Flush any pending outbound commands; further poll traffic will be
+    // silently dropped since the rig's comm/udp signal targets are gone.
+    queue->clear();
+    // Synchronously close comms so ~icomUdpBase() runs and sends the 0x05
+    // disconnect packet before we tell the frontend we're disconnected.
+    for (RIGCONFIG* radio : serverConfig.rigs) {
+        if (radio->rig != Q_NULLPTR && radio->rigThread != Q_NULLPTR && radio->rigThread->isRunning()) {
+            QMetaObject::invokeMethod(radio->rig, "closeComm", Qt::BlockingQueuedConnection);
+        }
+        radio->rigAvailable = false;
+    }
+    if (web != Q_NULLPTR) {
+        QMetaObject::invokeMethod(web, "setLanInfo", Qt::QueuedConnection,
+            Q_ARG(bool, true), Q_ARG(bool, false));
+    }
+}
+
+void servermain::reconnectLan()
+{
+    if (!prefs.enableLAN) return;
+    qInfo(logSystem()) << "reconnectLan() re-opening rig LAN session";
+    openRig();
+    if (web != Q_NULLPTR) {
+        QMetaObject::invokeMethod(web, "setLanInfo", Qt::QueuedConnection,
+            Q_ARG(bool, true), Q_ARG(bool, true));
     }
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -1797,6 +1797,12 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
             emit requestPowerOff();
         }
     }
+    else if (type == "disconnectLan") {
+        emit requestLanDisconnect();
+    }
+    else if (type == "reconnectLan") {
+        emit requestLanReconnect();
+    }
     else if (type == "getMemories") {
         if (!queue || !rigCaps) {
             QJsonObject err;
@@ -2079,6 +2085,9 @@ QJsonObject webServer::buildInfoJson() const
 #endif
     info["freedvModes"] = fdvModes;
 
+    info["isLan"] = lanMode;
+    info["lanConnected"] = lanConnected;
+
     if (rigCaps) {
         info["connected"] = true;
         info["model"] = rigCaps->modelName;
@@ -2245,6 +2254,9 @@ QJsonObject webServer::buildStatusJson()
         rigPoweredOn = powerState.value.toBool();
     }
     status["powerState"] = rigPoweredOn;
+
+    status["isLan"] = lanMode;
+    status["lanConnected"] = lanConnected;
 
     // FreeDV
     status["freedv"] = freedvEnabled;
@@ -2758,6 +2770,19 @@ codecType webServer::codecByteToType(quint8 codec)
     default:
         return LPCM;
     }
+}
+
+void webServer::setLanInfo(bool isLan, bool connected)
+{
+    bool changed = (lanMode != isLan) || (lanConnected != connected);
+    lanMode = isLan;
+    lanConnected = connected;
+    if (!changed) return;
+    QJsonObject obj;
+    obj["type"] = "lanStatus";
+    obj["isLan"] = lanMode;
+    obj["lanConnected"] = lanConnected;
+    sendJsonToAll(obj);
 }
 
 void webServer::setupAudio(quint8 codec, quint32 sampleRate)


### PR DESCRIPTION
## Summary
- Resolves #17: adds a web-only UI to release the radio's LAN slot so other apps (RS-BA1/wfview) can take over, and sends the 0x05 disconnect packet on clean shutdown.
- New Disconnect/Connect button on the power-off overlay (LAN only); state flows via a `lanStatus` WebSocket message plus `isLan`/`lanConnected` fields in `/api/v1/radio/{info,status}`.
- Fixes the follow-on bug where LAN reconnect left `rigCaps` unpopulated, causing "Unsupported command received from rig" spam and dead UI — resets `modelID`/`haveRigCaps` in `commonSetup()` and clears the queue's `rigCaps` pointer in `closeComm()` so `rigCapsUpdated` re-emits.

## Test plan
- [ ] LAN-connect to IC-7610, power off via UI, click Disconnect — verify 0x05 packet is sent and RS-BA1/wfview can then connect.
- [ ] Click Connect again, power on, confirm commands work and no "Unsupported command" log spam.
- [ ] Repeat disconnect/reconnect several times to confirm no QThread leaks and polling resumes each cycle.
- [ ] Quit wfweb while LAN-connected and confirm the radio releases the slot (clean shutdown).
- [ ] Non-LAN (serial) connection: confirm the Disconnect/Connect button is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)