### PR TITLE
Direwolf: Windows MSVC compatibility + CI hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,7 +454,6 @@ jobs:
   build-windows:
     name: Windows x86_64
     runs-on: windows-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout

--- a/resources/direwolf/README-vendoring.md
+++ b/resources/direwolf/README-vendoring.md
@@ -65,6 +65,18 @@ needs the modem + framing layer.
    etc. take their Windows code paths consistently — no pthread
    emulation needed.
 
+5. **`direwolf.h`** (MSVC compat) — add a `__restrict__` → `__restrict`
+   alias for MSVC. The `strlcpy_debug` / `strlcat_debug` prototypes
+   use the GCC-only `__restrict__` spelling; MSVC understands
+   `__restrict` (and the C99 `restrict`) but not the underscored form.
+
+6. **`ax25_pad.h` / `ax25_pad.c`** (MSVC compat) — change the
+   `src_file` parameter of `ax25_from_text_debug`, `ax25_from_frame_debug`,
+   `ax25_dup_debug`, and `ax25_delete_debug` from `char *` to
+   `const char *`. The macros that wrap them pass `__FILE__`, which
+   under MSVC's `Zc:strictStrings` is `const char[N]` and won't
+   implicitly bind to `char *`. GCC tolerates this; MSVC errors out.
+
 ## MSVC POSIX-header shims (`msvc-shim/`)
 
 `msvc-shim/unistd.h` and `msvc-shim/regex.h` are empty stubs added

--- a/resources/direwolf/README-vendoring.md
+++ b/resources/direwolf/README-vendoring.md
@@ -102,6 +102,10 @@ the includes are leftovers from upstream code paths we don't compile.
   - `dlq_rec_frame` (RX frame hook, routes to `DireWolfProcessor`)
   - `ptt_set`, `ptt_init`, `ptt_term`
   - `fx25_rec_bit`, `il2p_rec_bit`, `il2p_init`, `fx25_init`
+  - On MSVC only: `strsep` (BSD/glibc), `__builtin_popcount` (GCC
+    builtin, mapped to `__popcnt`), `localtime_r` (POSIX, mapped to
+    MSVC's `localtime_s`).  Direwolf's modem subset uses all three;
+    they're absent from MSVC's CRT.
 
 ## Updating from upstream
 

--- a/resources/direwolf/README-vendoring.md
+++ b/resources/direwolf/README-vendoring.md
@@ -69,6 +69,12 @@ needs the modem + framing layer.
    alias for MSVC. The `strlcpy_debug` / `strlcat_debug` prototypes
    use the GCC-only `__restrict__` spelling; MSVC understands
    `__restrict` (and the C99 `restrict`) but not the underscored form.
+   Same block also `#define`s `__attribute__(x)` to nothing on MSVC,
+   neutralising the GCC-only `__attribute__((format(...)))` hint on
+   `dw_printf` (textcolor.h) and the `__attribute__((aligned(16)))`
+   markers on float arrays in fsk_demod_state.h. The vendored modem
+   subset uses no SSE intrinsics that would actually require 16-byte
+   alignment, so dropping the hint is correctness-neutral.
 
 6. **`ax25_pad.h` / `ax25_pad.c`** (MSVC compat) — change the
    `src_file` parameter of `ax25_from_text_debug`, `ax25_from_frame_debug`,

--- a/resources/direwolf/README-vendoring.md
+++ b/resources/direwolf/README-vendoring.md
@@ -49,6 +49,31 @@ needs the modem + framing layer.
 2. **`demod_afsk.c`** — replace `exit(1)` in the unknown-profile init
    path with a `dw_printf` log and `return` so the host can recover.
 
+3. **`direwolf.h`** (MSVC compat) — replace the `#error` guards on
+   `_WIN32_WINNT` / `WINVER` with `#ifndef`. Qt and the MSVC runtime
+   pull `<windows.h>` in before Direwolf, so the upstream check trips
+   on every translation unit. The `#ifndef` form respects whatever
+   value the host has already set and only falls back to `0x0501` when
+   nothing is defined.
+
+4. **`direwolf.h`** (MSVC compat) — change the pthread-include guard
+   from `#if __WIN32__` to `#if __WIN32__ || defined(_WIN32)`. MSVC
+   doesn't predefine `__WIN32__` (only MinGW does), so without this
+   the POSIX branch would try to `#include <pthread.h>`. wfweb.pro
+   also forces `__WIN32__=1` on `win32-msvc` so the rest of the
+   `#if __WIN32__` branches in `dlq.c`, `dtime_now.c`, `ax25_pad.c`,
+   etc. take their Windows code paths consistently — no pthread
+   emulation needed.
+
+## MSVC POSIX-header shims (`msvc-shim/`)
+
+`msvc-shim/unistd.h` and `msvc-shim/regex.h` are empty stubs added
+to `INCLUDEPATH` ahead of the system headers on `win32-msvc` builds.
+Several vendored sources include `<unistd.h>` (and `ax25_pad.c`
+includes `<regex.h>`) unconditionally even though no symbols from
+those headers are actually called in the modem subset we vendor —
+the includes are leftovers from upstream code paths we don't compile.
+
 ## Companion file (not from upstream)
 
 - `wfweb_direwolf_stubs.c` — provides the symbols Dire Wolf expects to

--- a/resources/direwolf/msvc-shim/regex.h
+++ b/resources/direwolf/msvc-shim/regex.h
@@ -1,0 +1,11 @@
+/*
+ * MSVC shim — empty <regex.h>.
+ *
+ * ax25_pad.c includes POSIX <regex.h> but never references any regex API;
+ * it's a leftover from upstream Direwolf code paths we don't compile.
+ * MSVC has no native <regex.h> (only the C++ <regex>), so provide an
+ * empty stub here.
+ */
+#ifndef WFWEB_MSVC_SHIM_REGEX_H
+#define WFWEB_MSVC_SHIM_REGEX_H
+#endif

--- a/resources/direwolf/msvc-shim/unistd.h
+++ b/resources/direwolf/msvc-shim/unistd.h
@@ -1,0 +1,13 @@
+/*
+ * MSVC shim — empty <unistd.h>.
+ *
+ * Several vendored Direwolf .c files (demod.c, demod_afsk.c, demod_9600.c,
+ * dsp.c, dlq.c, gen_tone.c, multi_modem.c, xid.c) include <unistd.h>
+ * unconditionally even though the modem subset wfweb vendors never calls
+ * any of the POSIX functions it would declare.  MSVC has no native
+ * <unistd.h>; this empty stub lets those translation units parse so the
+ * rest of the file compiles via direwolf.h's __WIN32__ branch.
+ */
+#ifndef WFWEB_MSVC_SHIM_UNISTD_H
+#define WFWEB_MSVC_SHIM_UNISTD_H
+#endif

--- a/resources/direwolf/src/ax25_pad.c
+++ b/resources/direwolf/src/ax25_pad.c
@@ -292,7 +292,7 @@ packet_t ax25_new (void)
  *------------------------------------------------------------------------------*/
 
 #if AX25MEMDEBUG
-void ax25_delete_debug (packet_t this_p, char *src_file, int src_line)
+void ax25_delete_debug (packet_t this_p, const char *src_file, int src_line)
 #else
 void ax25_delete (packet_t this_p)
 #endif
@@ -380,7 +380,7 @@ void ax25_delete (packet_t this_p)
  *------------------------------------------------------------------------------*/
 
 #if AX25MEMDEBUG
-packet_t ax25_from_text_debug (char *monitor, int strict, char *src_file, int src_line)
+packet_t ax25_from_text_debug (char *monitor, int strict, const char *src_file, int src_line)
 #else
 packet_t ax25_from_text (char *monitor, int strict)
 #endif
@@ -637,7 +637,7 @@ packet_t ax25_from_text (char *monitor, int strict)
  *------------------------------------------------------------------------------*/
 
 #if AX25MEMDEBUG
-packet_t ax25_from_frame_debug (unsigned char *fbuf, int flen, alevel_t alevel, char *src_file, int src_line)
+packet_t ax25_from_frame_debug (unsigned char *fbuf, int flen, alevel_t alevel, const char *src_file, int src_line)
 #else
 packet_t ax25_from_frame (unsigned char *fbuf, int flen, alevel_t alevel)
 #endif
@@ -709,7 +709,7 @@ packet_t ax25_from_frame (unsigned char *fbuf, int flen, alevel_t alevel)
 
 
 #if AX25MEMDEBUG
-packet_t ax25_dup_debug (packet_t copy_from, char *src_file, int src_line)
+packet_t ax25_dup_debug (packet_t copy_from, const char *src_file, int src_line)
 #else
 packet_t ax25_dup (packet_t copy_from)
 #endif

--- a/resources/direwolf/src/ax25_pad.h
+++ b/resources/direwolf/src/ax25_pad.h
@@ -343,16 +343,16 @@ extern int ax25memdebug_get (void);
 extern int ax25memdebug_seq (packet_t this_p);
 
 
-extern packet_t ax25_from_text_debug (char *monitor, int strict, char *src_file, int src_line);
+extern packet_t ax25_from_text_debug (char *monitor, int strict, const char *src_file, int src_line);
 #define ax25_from_text(m,s) ax25_from_text_debug(m,s,__FILE__,__LINE__)
 
-extern packet_t ax25_from_frame_debug (unsigned char *data, int len, alevel_t alevel, char *src_file, int src_line);
+extern packet_t ax25_from_frame_debug (unsigned char *data, int len, alevel_t alevel, const char *src_file, int src_line);
 #define ax25_from_frame(d,l,a) ax25_from_frame_debug(d,l,a,__FILE__,__LINE__);
 
-extern packet_t ax25_dup_debug (packet_t copy_from, char *src_file, int src_line);
+extern packet_t ax25_dup_debug (packet_t copy_from, const char *src_file, int src_line);
 #define ax25_dup(p) ax25_dup_debug(p,__FILE__,__LINE__);
 
-extern void ax25_delete_debug (packet_t pp, char *src_file, int src_line);
+extern void ax25_delete_debug (packet_t pp, const char *src_file, int src_line);
 #define ax25_delete(p) ax25_delete_debug(p,__FILE__,__LINE__);
 
 #else

--- a/resources/direwolf/src/direwolf.h
+++ b/resources/direwolf/src/direwolf.h
@@ -22,15 +22,16 @@
 
 #if __WIN32__
 
-#ifdef _WIN32_WINNT
-#error	Include "direwolf.h" before any windows system files.
-#endif
-#ifdef WINVER
-#error	Include "direwolf.h" before any windows system files.
-#endif
-
+/* wfweb: Qt headers (and MSVC's own runtime headers) routinely pull in
+ * <windows.h> before Direwolf, so the upstream "must be first" #error
+ * trips on every MSVC translation unit.  Switch to idempotent #ifndef
+ * defines and respect any value the host has already set. */
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0501     /* Minimum OS version is XP. */
+#endif
+#ifndef WINVER
 #define WINVER       0x0501     /* Minimum OS version is XP. */
+#endif
 
 // Other values are in Windows SDK sdkddkver.h
 //	0x0600 - Windows Vista
@@ -126,7 +127,7 @@
 #define SLEEP_MS(n) usleep((n)*1000)
 #endif
 
-#if __WIN32__
+#if __WIN32__ || defined(_WIN32)
 
 #define PTW32_STATIC_LIB
 //#include "pthreads/pthread.h"

--- a/resources/direwolf/src/direwolf.h
+++ b/resources/direwolf/src/direwolf.h
@@ -15,9 +15,14 @@
 /* wfweb: MSVC accepts __restrict (single underscore) and the C99 keyword
  * restrict, but not GCC's __restrict__ spelling used in the strlcpy_debug
  * prototypes below.  Map them so the headers parse on every supported
- * compiler. */
+ * compiler.  Same idea for __attribute__((...)) in textcolor.h /
+ * fsk_demod_state.h: MSVC has no equivalent and the attributes here
+ * (printf format hints, aligned(16) on float arrays) are purely
+ * advisory — the modem subset wfweb vendors uses no SSE intrinsics
+ * that would actually require 16-byte alignment. */
 #if defined(_MSC_VER) && !defined(__GNUC__)
 #define __restrict__ __restrict
+#define __attribute__(x)
 #endif
 
 /*

--- a/resources/direwolf/src/direwolf.h
+++ b/resources/direwolf/src/direwolf.h
@@ -12,6 +12,14 @@
 #ifndef DIREWOLF_H
 #define DIREWOLF_H 1
 
+/* wfweb: MSVC accepts __restrict (single underscore) and the C99 keyword
+ * restrict, but not GCC's __restrict__ spelling used in the strlcpy_debug
+ * prototypes below.  Map them so the headers parse on every supported
+ * compiler. */
+#if defined(_MSC_VER) && !defined(__GNUC__)
+#define __restrict__ __restrict
+#endif
+
 /*
  * Support Windows XP and later.
  *

--- a/resources/direwolf/wfweb_direwolf_stubs.c
+++ b/resources/direwolf/wfweb_direwolf_stubs.c
@@ -174,3 +174,52 @@ size_t strlcat_debug(char *dst, const char *src, size_t siz,
     dst[dstlen + copy] = '\0';
     return dstlen + srclen;
 }
+
+/* ----- MSVC POSIX/GCC shims -----
+ *
+ * MSVC's CRT lacks strsep (BSD/glibc), __builtin_popcount (GCC builtin),
+ * and localtime_r (POSIX).  Direwolf's vendored modem subset uses all
+ * three.  Provide minimal native implementations here so the link
+ * succeeds; on MinGW/Linux/macOS these definitions are simply unused
+ * because the system already supplies the symbols. */
+
+#if defined(_MSC_VER) && !defined(__GNUC__)
+
+#include <time.h>
+#include <intrin.h>     /* __popcnt */
+
+char *strsep(char **stringp, const char *delim)
+{
+    char *start = *stringp;
+    char *p;
+    if (start == NULL) return NULL;
+    p = start;
+    while (*p != '\0') {
+        const char *d;
+        for (d = delim; *d != '\0'; d++) {
+            if (*p == *d) {
+                *p = '\0';
+                *stringp = p + 1;
+                return start;
+            }
+        }
+        p++;
+    }
+    *stringp = NULL;
+    return start;
+}
+
+int __builtin_popcount(unsigned int x)
+{
+    return (int)__popcnt(x);
+}
+
+/* MSVC has localtime_s with reversed argument order — wrap it to look
+ * like POSIX localtime_r so the call sites in dtime_now.c don't change. */
+struct tm *localtime_r(const time_t *timep, struct tm *result)
+{
+    if (localtime_s(result, timep) != 0) return NULL;
+    return result;
+}
+
+#endif  /* _MSC_VER && !__GNUC__ */

--- a/wfweb.pro
+++ b/wfweb.pro
@@ -261,6 +261,17 @@ INCLUDEPATH += $$PWD/resources/direwolf/src $$PWD/resources/direwolf
 # macOS libc has strlcpy/strlcat; tell direwolf.h so it skips its macro shim,
 # which otherwise rewrites the SDK <string.h> declarations and breaks builds.
 macx:DEFINES += HAVE_STRLCPY HAVE_STRLCAT
+# MSVC doesn't predefine __WIN32__ (MinGW does), so direwolf.h would fall
+# through to the POSIX branch and pull in <pthread.h>.  Force __WIN32__ on so
+# every Direwolf source consistently takes its Windows code path (CRITICAL_SECTION
+# in dlq.c, GetSystemTimeAsFileTime in dtime_now.c, etc.) — no pthread emulation
+# needed.  The msvc-shim dir provides empty <unistd.h> / <regex.h> headers for
+# the gratuitous POSIX includes upstream Direwolf left in the modem sources;
+# none of the symbols those headers would declare are actually called.
+win32-msvc {
+    DEFINES += __WIN32__=1
+    INCLUDEPATH = $$PWD/resources/direwolf/msvc-shim $$INCLUDEPATH
+}
 # Vendored Dire Wolf C predates current warning hygiene; quiet the noise
 # so wfweb's own C++ warnings stay readable.  Only affects C compilation
 # (wfweb itself is C++), so genuine warnings in our code are unaffected.

--- a/wfweb.pro
+++ b/wfweb.pro
@@ -270,6 +270,10 @@ macx:DEFINES += HAVE_STRLCPY HAVE_STRLCAT
 # none of the symbols those headers would declare are actually called.
 win32-msvc {
     DEFINES += __WIN32__=1
+    # MSVC's <math.h> hides M_PI etc. unless _USE_MATH_DEFINES is set
+    # before the include — Direwolf's DSP code (gen_tone.c, dsp.c,
+    # demod_afsk.c) uses M_PI directly.
+    DEFINES += _USE_MATH_DEFINES
     INCLUDEPATH = $$PWD/resources/direwolf/msvc-shim $$INCLUDEPATH
 }
 # Vendored Dire Wolf C predates current warning hygiene; quiet the noise


### PR DESCRIPTION
## Summary

Six commits making the vendored Direwolf modem subset actually compile and link on Windows MSVC, plus one CI fix so future Windows regressions don't ship silently.

The Direwolf vendoring assumed a MinGW-style toolchain. MSVC tripped over a cascade of POSIX/GCC-isms that were invisible until builds #122–#126 (caught only because the Windows job had `continue-on-error: true`).

### Windows MSVC compat

- **`__WIN32__=1` for `win32-msvc`** — MinGW predefines `__WIN32__`, MSVC only `_WIN32`. With this set, `dlq.c`, `dtime_now.c`, `ax25_pad.c`, etc. take their Windows code paths consistently — no pthread4w needed.
- **`direwolf.h`**: `_WIN32_WINNT` / `WINVER` guards switched from `#error` to `#ifndef` (Qt pulls `<windows.h>` in first); pthread-include guard accepts `_WIN32` too.
- **MSVC POSIX shims** (`resources/direwolf/msvc-shim/`): empty `<unistd.h>` and `<regex.h>` for the unconditional includes upstream Direwolf left around. The symbols those headers would declare are never called in the vendored modem subset.
- **`__restrict__` → `__restrict`** alias on MSVC; **`__attribute__(x)` defined to nothing** (the only uses are a `printf`-format hint and `aligned(16)` markers on float arrays — no SSE intrinsics that would actually require the alignment).
- **`const char *src_file`** in `ax25_pad.h` / `ax25_pad.c` debug shims (MSVC's `Zc:strictStrings` rejects `__FILE__` binding to `char *`).
- **`_USE_MATH_DEFINES`** so MSVC's `<math.h>` exposes `M_PI`.
- **Link-time shims** in `wfweb_direwolf_stubs.c`, gated `_MSC_VER && !__GNUC__`: native `strsep` (BSD/glibc), `__builtin_popcount` (mapped to `__popcnt`), `localtime_r` (mapped to `localtime_s`).

Linux/macOS paths are unchanged; every shim is gated behind the MSVC compiler check or the `win32-msvc` qmake spec.

### CI

- **Drop `continue-on-error: true`** from the Windows build job. Without it, every Windows failure on the Direwolf branch reported the overall workflow as success because `Publish release` (which is in `needs:`) still ran.

Patch list documented in `resources/direwolf/README-vendoring.md`.

## Test plan

- [x] Linux build: clean
- [x] Build #127 on `Direwolf` (https://github.com/adecarolis/wfweb/actions/runs/24959019204): all jobs green including Windows x86_64
- [x] Workflow change verified: build #125 showed `Publish release: skipped` when Windows failed
- [ ] Manual smoke test on Windows (per @adecarolis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)