### PR TITLE
reporters: add pskreporter.info reporting for FT8/FT4 (#44)

### DIFF
--- a/include/pskreporter.h
+++ b/include/pskreporter.h
@@ -1,0 +1,87 @@
+#ifndef PSKREPORTER_H
+#define PSKREPORTER_H
+
+#include "spotreporter.h"
+#include <QUdpSocket>
+#include <QHostAddress>
+#include <QHostInfo>
+#include <QTimer>
+#include <QList>
+
+// PSK Reporter — sends FT8/FT4 (and other digital mode) decode spots to
+// pskreporter.info using the IPFIX (RFC 5101) protocol over UDP port 4739.
+//
+// Spots are buffered and flushed on a timer (default ~5 minutes) to keep
+// the reporting load low and align with how other clients (WSJT-X, JS8Call)
+// behave on the network.
+class PskReporter : public SpotReporter
+{
+    Q_OBJECT
+public:
+    explicit PskReporter(QObject *parent = nullptr);
+    ~PskReporter() override;
+
+    void setStation(const QString &callsign, const QString &grid) override;
+    void connectToService() override;
+    void disconnectFromService() override;
+    void updateFrequency(quint64 hz) override;
+    void updateTx(const QString &mode, bool transmitting) override;
+    void updateRxSpot(const QString &callsign, const QString &mode, int snr) override;
+
+    // Extended spot record carrying the decoded station's grid (when known).
+    void updateRxSpotWithGrid(const QString &callsign, const QString &grid,
+                              const QString &mode, int snr);
+
+    // Force an immediate flush of buffered spots.  Useful before shutdown
+    // or when the user explicitly disables reporting.
+    void flush();
+
+    State state() const override { return state_; }
+
+private slots:
+    void onLookupFinished(const QHostInfo &info);
+    void onSendTimer();
+    void onSocketError(QAbstractSocket::SocketError error);
+
+private:
+    void setState(State s);
+    void sendPacket();
+    QByteArray buildPacket(bool withTemplates);
+    static QByteArray encodeVarField(const QByteArray &data);
+
+    static constexpr const char *DEFAULT_HOST = "report.pskreporter.info";
+    static constexpr quint16 DEFAULT_PORT = 4739;
+    // Flush every 5 minutes; matches the upstream tools' default cadence.
+    static constexpr int SEND_INTERVAL_MS = 5 * 60 * 1000;
+    // Re-send templates at most once per hour to keep collectors in sync.
+    static constexpr qint64 TEMPLATE_REFRESH_SECS = 60 * 60;
+
+    QUdpSocket *socket_ = nullptr;
+    QTimer *sendTimer_ = nullptr;
+    QHostAddress serverAddr_;
+    bool dnsResolved_ = false;
+    int dnsLookupId_ = -1;
+
+    QString callsign_;
+    QString grid_;
+    QString currentMode_;
+    quint64 currentFreq_ = 0;
+
+    quint32 sequence_ = 0;
+    quint32 observationDomainId_ = 0;
+    qint64 lastTemplateTime_ = 0;
+
+    struct Spot {
+        QString callsign;
+        QString grid;
+        QString mode;
+        int snr;
+        quint64 freq;
+        qint64 timeSeconds;
+    };
+    QList<Spot> pendingSpots_;
+
+    State state_ = Disconnected;
+};
+
+#endif // PSKREPORTER_H

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -33,6 +33,7 @@
 #include "audioconverter.h"
 #include "freedvprocessor.h"
 #include "freedvreporter.h"
+#include "pskreporter.h"
 #include "radeprocessor.h"
 #include "direwolfprocessor.h"
 #include "ax25linkprocessor.h"
@@ -140,6 +141,7 @@ private slots:
     void onFreeDVStats(float snr, bool sync);
     void onFreeDVRxCallsign(const QString &callsign);
     void onReporterStateChanged(int state);
+    void onPskReporterStateChanged(int state);
     void drainFreeDVTxBuffer();
 
     // RADE V1
@@ -175,6 +177,11 @@ private:
     void sendJsonTo(QWebSocket *client, const QJsonObject &obj);
     void startReporterSnrTimer();
     void stopReporterSnrTimer();
+    // Notify clients of the current state of either reporter.  The displayed
+    // state distinguishes "waiting" (checkbox on but the matching mode isn't
+    // active) from "connecting" (actually trying to reach the server).
+    void notifyFreedvReporterStatus();
+    void notifyPskReporterStatus();
     void sendBinaryToAll(const QByteArray &data);
     void sendBinaryToAudioClients(const QByteArray &data);
     // Common TX-audio writer.  Takes mono int16 LE PCM, expands to stereo
@@ -270,9 +277,13 @@ private:
     FreeDVProcessor *freedvProcessor = nullptr;
     QThread *freedvThread = nullptr;
     FreeDVReporter *freedvReporter = nullptr;
+    PskReporter *pskReporter = nullptr;
     QString reporterCallsign;
     QString reporterGrid;
-    bool reporterEnabled = false;
+    bool reporterEnabled = false;       // FreeDV Reporter toggle
+    bool pskReporterEnabled = false;    // pskreporter.info toggle (FT8/FT4)
+    bool digiActive = false;            // browser DIGI panel open (FT8/FT4)
+    QString digiMode = QStringLiteral("FT8");
     bool freedvEnabled = false;
     int freedvMode = 0;
     QString freedvModeName = QStringLiteral("RADE");

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -2243,6 +2243,13 @@ body.digi-open .digi-bar {
                 </label>
                 <span id="digiReporterStatus" style="font-size:10px;color:#556;margin-left:8px"></span>
             </div>
+            <div class="digi-settings-field" style="margin-top:6px">
+                <label style="display:flex;align-items:center;gap:6px;color:#8cf;font-size:12px;cursor:pointer">
+                    <input type="checkbox" id="digiPskReporterEnable">
+                    <span>pskreporter.info Reporter (FT8/FT4)</span>
+                </label>
+                <span id="digiPskReporterStatus" style="font-size:10px;color:#556;margin-left:8px"></span>
+            </div>
             <button id="digiSettingsCloseBtn" class="digi-settings-close">Close</button>
         </div>
 
@@ -2894,6 +2901,9 @@ function handleMessage(msg) {
             break;
         case 'reporterStatus':
             updateReporterStatus(msg);
+            break;
+        case 'pskReporterStatus':
+            updatePskReporterStatus(msg);
             break;
         case 'radeCallsign':
             radeRxCallsign = msg.callsign || '';
@@ -5863,16 +5873,24 @@ function digiPeriod() { return digiMode === 'FT4' ? 7.5 : 15; }
 function getMyCall() { return ((document.getElementById('digiMyCall') || {}).value || '').toUpperCase(); }
 function getMyGrid() { return ((document.getElementById('digiGrid') || {}).value || '').toUpperCase().substr(0, 4); }
 
-// --- FreeDV Reporter ---
+// --- Reporters (FreeDV + pskreporter.info) ---
 function sendReporterConfig() {
-    var cb = document.getElementById('digiReporterEnable');
-    if (!cb || !ws || ws.readyState !== 1) return;
+    var fdvCb = document.getElementById('digiReporterEnable');
+    var pskCb = document.getElementById('digiPskReporterEnable');
+    if (!ws || ws.readyState !== 1) return;
     send({
         cmd: 'setReporter',
-        enabled: cb.checked,
+        freedvEnabled: !!(fdvCb && fdvCb.checked),
+        pskEnabled: !!(pskCb && pskCb.checked),
         callsign: getMyCall(),
         grid: getMyGrid()
     });
+}
+function reporterStateColor(state) {
+    if (state === 'connected') return '#0c6';
+    if (state === 'error')     return '#f44';
+    if (state === 'waiting')   return '#fa3';   // amber: armed but mode not active
+    return '#556';                              // disconnected / connecting / unknown
 }
 function updateReporterStatus(msg) {
     if (msg.enabled !== undefined) reporterEnabled = msg.enabled;
@@ -5881,20 +5899,81 @@ function updateReporterStatus(msg) {
     var st = document.getElementById('digiReporterStatus');
     if (cb && msg.enabled !== undefined) cb.checked = msg.enabled;
     if (st) {
-        st.textContent = msg.state || '';
-        st.style.color = msg.state === 'connected' ? '#0c6' : msg.state === 'error' ? '#f44' : '#556';
+        st.textContent = msg.state === 'waiting' ? 'waiting for FreeDV' : (msg.state || '');
+        st.style.color = reporterStateColor(msg.state);
     }
     // Refresh the FreeDV indicator bar to update the reporter dot
     if (freedvEnabled) updateFreeDVStatus({});
 }
+function updatePskReporterStatus(msg) {
+    var cb = document.getElementById('digiPskReporterEnable');
+    var st = document.getElementById('digiPskReporterStatus');
+    if (cb && msg.enabled !== undefined) cb.checked = msg.enabled;
+    if (st) {
+        st.textContent = msg.state === 'waiting' ? 'waiting for FT8/FT4' : (msg.state || '');
+        st.style.color = reporterStateColor(msg.state);
+    }
+}
+// Forward a single FT8/FT4 decode to the backend so it can be relayed to
+// pskreporter.info.  The browser is the only place that sees decoded
+// messages, so callsign + (optional) grid extraction lives here.
+function reportDigiSpot(d) {
+    if (!ws || ws.readyState !== 1) return;
+    var parts = (d.msg || '').trim().split(/\s+/);
+    if (parts.length < 2) return;
+    var first = parts[0].toUpperCase();
+    var fromCall = null, grid = '';
+    if (first === 'CQ' || first === 'QRZ') {
+        // "CQ [modifier]? CALL [GRID]?" — callsign is the first token with
+        // a digit that is NOT a 4-char Maidenhead grid (e.g. FN42).
+        for (var p = 1; p < parts.length; p++) {
+            var tok = parts[p].toUpperCase();
+            if (/^[A-Z]{2}\d{2}$/.test(tok)) {
+                if (fromCall && !grid) grid = tok;
+                continue;
+            }
+            if (!fromCall && /\d/.test(tok) && /[A-Z]/.test(tok)) fromCall = tok;
+        }
+    } else {
+        // Standard QSO: "THEIRCALL MYCALL <reply>" — sender is parts[1].
+        var maybe = parts[1].toUpperCase();
+        if (/\d/.test(maybe) && /[A-Z]/.test(maybe)) fromCall = maybe;
+        for (var q = 2; q < parts.length; q++) {
+            var t = parts[q].toUpperCase();
+            if (/^[A-Z]{2}\d{2}$/.test(t)) { grid = t; break; }
+        }
+    }
+    if (!fromCall || fromCall.length < 3) return;
+    // DIGI mode is always USB, so on-air freq = dial + audio offset.
+    var rfFreq = Math.round((currentFreq || 0) + (d.freq || 0));
+    if (rfFreq <= 0) return;
+    send({
+        cmd: 'reportDigiSpot',
+        callsign: fromCall,
+        grid: grid,
+        mode: digiMode,
+        snr: Math.round(d.snr || 0),
+        freq: rfFreq
+    });
+}
+
 function initReporter() {
     var cb = document.getElementById('digiReporterEnable');
-    if (!cb) return;
-    try { cb.checked = localStorage.getItem('digiReporterEnabled') === '1'; } catch(e) {}
-    cb.addEventListener('change', function() {
-        try { localStorage.setItem('digiReporterEnabled', this.checked ? '1' : '0'); } catch(e) {}
-        sendReporterConfig();
-    });
+    if (cb) {
+        try { cb.checked = localStorage.getItem('digiReporterEnabled') === '1'; } catch(e) {}
+        cb.addEventListener('change', function() {
+            try { localStorage.setItem('digiReporterEnabled', this.checked ? '1' : '0'); } catch(e) {}
+            sendReporterConfig();
+        });
+    }
+    var pskCb = document.getElementById('digiPskReporterEnable');
+    if (pskCb) {
+        try { pskCb.checked = localStorage.getItem('digiPskReporterEnabled') === '1'; } catch(e) {}
+        pskCb.addEventListener('change', function() {
+            try { localStorage.setItem('digiPskReporterEnabled', this.checked ? '1' : '0'); } catch(e) {}
+            sendReporterConfig();
+        });
+    }
 }
 
 // Check that MY CALL and MY GRID are set before transmitting.
@@ -5942,6 +6021,8 @@ function toggleDigiBar() {
     if (digiBarVisible) {
         // Disable FreeDV if active — modes are mutually exclusive
         if (freedvEnabled) send({ cmd: 'setFreeDV', enabled: false });
+        // Tell the backend FT8/FT4 is now active so PSK Reporter can connect.
+        send({ cmd: 'setDigiActive', active: true, mode: digiMode });
         bar.classList.remove('hidden');
         document.body.classList.add('digi-open');
         // FT8 requires USB — set it automatically on open
@@ -5970,6 +6051,7 @@ function toggleDigiBar() {
     } else {
         bar.classList.add('hidden');
         document.body.classList.remove('digi-open');
+        send({ cmd: 'setDigiActive', active: false });
         stopDigiTune();
         stopDigiPeriodTimer();
         // Restore USB Mod Level
@@ -6440,6 +6522,7 @@ function onFt8DecodeResult(results, decodedSlotIndex) {
                   freq: results[i].freq, msg: results[i].msg,
                   slotIndex: decodedSlotIndex };
         digiDecodes.push(d);
+        reportDigiSpot(d);
         var toUs = myCall && d.msg.toUpperCase().indexOf(myCall) >= 0;
         var onRxFreq = Math.abs(d.freq - digiRxFreq) <= 10;
         if (toUs || onRxFreq) {
@@ -7923,6 +8006,7 @@ function initDigiHandlers() {
             digiMode = (digiMode === 'FT8') ? 'FT4' : 'FT8';
             this.textContent = digiMode;
             if (digiBarVisible) {
+                send({ cmd: 'setDigiActive', active: true, mode: digiMode });
                 stopDigiPeriodTimer();
                 resetDigiRxBuffer();
                 startDigiPeriodTimer();

--- a/src/pskreporter.cpp
+++ b/src/pskreporter.cpp
@@ -1,0 +1,384 @@
+#include "pskreporter.h"
+#include "logcategories.h"
+
+#include <QDataStream>
+#include <QDateTime>
+#include <QRandomGenerator>
+#include <QtEndian>
+
+// IPFIX (RFC 5101) wire format used by pskreporter.info.
+//
+//   Message header (16 bytes)
+//     uint16 version            = 10  (IPFIX)
+//     uint16 length             = total bytes in this UDP datagram
+//     uint32 exportTime         = unix seconds
+//     uint32 sequenceNumber     = increments across messages from this exporter
+//     uint32 observationDomain  = random 32-bit ID, stable for the session
+//
+//   Template Set (set ID = 2):
+//     uint16 setID = 2
+//     uint16 setLength
+//     {  Template record
+//          uint16 templateID            (must be >= 256)
+//          uint16 fieldCount
+//          field specifiers...
+//     } [+ pad to 4-byte boundary]
+//
+//   Field specifier:
+//     uint16 informationElementID  (high bit = enterprise-specific)
+//     uint16 fieldLength           (0xFFFF for variable length)
+//     [uint32 enterpriseNumber]    (only if E-bit set)
+//
+//   Data Set (set ID = matching template's templateID):
+//     uint16 setID
+//     uint16 setLength
+//     records...
+//     [pad to 4-byte boundary with zeros]
+//
+//   Variable-length field encoding inside a record:
+//     - if length <  255:  1 byte length + bytes
+//     - if length >= 255:  0xFF + uint16 length + bytes
+//
+// All multi-byte integers are big-endian.  PSKReporter information elements
+// live under enterprise number 30351.
+
+namespace {
+
+constexpr quint16 IPFIX_VERSION       = 10;
+constexpr quint32 PSK_ENTERPRISE_PEN  = 30351;
+
+// Custom template IDs.  Any value >= 256 works; pick distinct constants and
+// keep them stable across messages so the collector can match data sets to
+// the templates it has on file.
+constexpr quint16 RECEIVER_TEMPLATE_ID = 0x50E2;
+constexpr quint16 SENDER_TEMPLATE_ID   = 0x50E3;
+
+// PSKReporter enterprise-specific information element IDs (high bit set on
+// the wire — but we store the raw 15-bit value here and OR in 0x8000 at
+// emit time).
+constexpr quint16 IE_RECEIVER_CALLSIGN     = 0x8002;
+constexpr quint16 IE_RECEIVER_LOCATOR      = 0x8004;
+constexpr quint16 IE_RECEIVER_SOFTWARE     = 0x8008;
+constexpr quint16 IE_RECEIVER_ANTENNA      = 0x8009;
+
+constexpr quint16 IE_SENDER_CALLSIGN       = 0x8001;
+constexpr quint16 IE_SENDER_LOCATOR        = 0x8003;
+constexpr quint16 IE_SENDER_FREQUENCY      = 0x8005;  // 4 bytes, Hz
+constexpr quint16 IE_SENDER_SNR            = 0x8006;  // 1 byte signed
+constexpr quint16 IE_SENDER_MODE           = 0x8007;
+// IANA-assigned standard element (no enterprise bit)
+constexpr quint16 IE_FLOW_START_SECONDS    = 150;     // 4 bytes, unix sec
+
+// Append a uint16 in big-endian order.
+inline void appendU16(QByteArray &b, quint16 v)
+{
+    b.append(static_cast<char>((v >> 8) & 0xFF));
+    b.append(static_cast<char>(v & 0xFF));
+}
+
+inline void appendU32(QByteArray &b, quint32 v)
+{
+    b.append(static_cast<char>((v >> 24) & 0xFF));
+    b.append(static_cast<char>((v >> 16) & 0xFF));
+    b.append(static_cast<char>((v >> 8) & 0xFF));
+    b.append(static_cast<char>(v & 0xFF));
+}
+
+inline void writeU16At(QByteArray &b, int pos, quint16 v)
+{
+    b[pos]     = static_cast<char>((v >> 8) & 0xFF);
+    b[pos + 1] = static_cast<char>(v & 0xFF);
+}
+
+// Field specifier for an enterprise-specific information element.
+inline void appendFieldSpec(QByteArray &b, quint16 ieId, quint16 length, quint32 pen)
+{
+    appendU16(b, ieId);   // high bit already set in the constant
+    appendU16(b, length);
+    appendU32(b, pen);
+}
+
+// Field specifier for a standard IANA element (no enterprise bit / PEN).
+inline void appendStandardFieldSpec(QByteArray &b, quint16 ieId, quint16 length)
+{
+    appendU16(b, ieId);
+    appendU16(b, length);
+}
+
+// Pad with zero bytes to bring the buffer length up to a 4-byte multiple.
+inline void padTo4(QByteArray &b)
+{
+    while (b.size() % 4) b.append('\0');
+}
+
+} // namespace
+
+PskReporter::PskReporter(QObject *parent)
+    : SpotReporter(parent)
+{
+    socket_ = new QUdpSocket(this);
+    connect(socket_, QOverload<QAbstractSocket::SocketError>::of(&QUdpSocket::error),
+            this, &PskReporter::onSocketError);
+
+    sendTimer_ = new QTimer(this);
+    sendTimer_->setInterval(SEND_INTERVAL_MS);
+    connect(sendTimer_, &QTimer::timeout, this, &PskReporter::onSendTimer);
+
+    // 32-bit observation domain ID, stable for the lifetime of this object.
+    observationDomainId_ = QRandomGenerator::global()->generate();
+    if (observationDomainId_ == 0) observationDomainId_ = 1;
+}
+
+PskReporter::~PskReporter()
+{
+    disconnectFromService();
+}
+
+void PskReporter::setStation(const QString &callsign, const QString &grid)
+{
+    callsign_ = callsign.toUpper().trimmed();
+    grid_ = grid.toUpper().trimmed();
+}
+
+void PskReporter::connectToService()
+{
+    if (callsign_.isEmpty() || grid_.isEmpty()) {
+        qWarning() << "PskReporter: cannot start without callsign and grid";
+        return;
+    }
+    if (state_ == Connected || state_ == Connecting) return;
+
+    setState(Connecting);
+
+    // The "connect" step is just a DNS resolve; UDP itself is connectionless.
+    // Once we have an address the timer starts and the next flush will go out.
+    dnsLookupId_ = QHostInfo::lookupHost(QString::fromLatin1(DEFAULT_HOST),
+                                         this, &PskReporter::onLookupFinished);
+    qInfo() << "PskReporter: resolving" << DEFAULT_HOST;
+}
+
+void PskReporter::disconnectFromService()
+{
+    if (state_ == Disconnected) return;
+
+    // Send any buffered spots before going away — losing the last batch on
+    // every shutdown would skew the heatmap.
+    if (dnsResolved_ && !pendingSpots_.isEmpty())
+        sendPacket();
+
+    sendTimer_->stop();
+    if (dnsLookupId_ >= 0) {
+        QHostInfo::abortHostLookup(dnsLookupId_);
+        dnsLookupId_ = -1;
+    }
+    pendingSpots_.clear();
+    setState(Disconnected);
+}
+
+void PskReporter::updateFrequency(quint64 hz)
+{
+    currentFreq_ = hz;
+}
+
+void PskReporter::updateTx(const QString &mode, bool transmitting)
+{
+    Q_UNUSED(transmitting);
+    if (!mode.isEmpty()) currentMode_ = mode;
+}
+
+void PskReporter::updateRxSpot(const QString &callsign, const QString &mode, int snr)
+{
+    updateRxSpotWithGrid(callsign, QString(), mode, snr);
+}
+
+void PskReporter::updateRxSpotWithGrid(const QString &callsign, const QString &grid,
+                                       const QString &mode, int snr)
+{
+    if (state_ != Connected && state_ != Connecting) return;
+    if (callsign.isEmpty() || currentFreq_ == 0) return;
+
+    Spot s;
+    s.callsign = callsign.toUpper().trimmed();
+    s.grid = grid.toUpper().trimmed();
+    s.mode = mode.isEmpty() ? currentMode_ : mode;
+    s.snr = qBound(-128, snr, 127);
+    s.freq = currentFreq_;
+    s.timeSeconds = QDateTime::currentSecsSinceEpoch();
+    pendingSpots_.append(s);
+    qInfo() << "PskReporter: queued spot" << s.callsign
+            << "grid=" << s.grid << "mode=" << s.mode
+            << "snr=" << s.snr << "freq=" << s.freq;
+}
+
+void PskReporter::flush()
+{
+    if (dnsResolved_ && !pendingSpots_.isEmpty()) sendPacket();
+}
+
+void PskReporter::onLookupFinished(const QHostInfo &info)
+{
+    dnsLookupId_ = -1;
+    if (info.error() != QHostInfo::NoError || info.addresses().isEmpty()) {
+        qWarning() << "PskReporter: DNS lookup failed:" << info.errorString();
+        setState(Error);
+        return;
+    }
+    // Prefer IPv4 — pskreporter.info's collector listens on both, but IPv4
+    // is the documented default and what every other tool uses.
+    serverAddr_ = info.addresses().first();
+    for (const QHostAddress &a : info.addresses()) {
+        if (a.protocol() == QAbstractSocket::IPv4Protocol) {
+            serverAddr_ = a;
+            break;
+        }
+    }
+    dnsResolved_ = true;
+    qInfo() << "PskReporter: server resolved to" << serverAddr_.toString()
+            << "as" << callsign_ << grid_;
+
+    setState(Connected);
+    sendTimer_->start();
+}
+
+void PskReporter::onSendTimer()
+{
+    if (!dnsResolved_) return;
+    if (pendingSpots_.isEmpty()) return;
+    sendPacket();
+}
+
+void PskReporter::onSocketError(QAbstractSocket::SocketError error)
+{
+    Q_UNUSED(error);
+    qWarning() << "PskReporter: socket error:" << socket_->errorString();
+}
+
+void PskReporter::setState(State s)
+{
+    if (state_ != s) {
+        state_ = s;
+        emit stateChanged(s);
+    }
+}
+
+QByteArray PskReporter::encodeVarField(const QByteArray &data)
+{
+    QByteArray out;
+    int n = data.size();
+    if (n < 255) {
+        out.append(static_cast<char>(n));
+    } else {
+        out.append(static_cast<char>(0xFF));
+        appendU16(out, static_cast<quint16>(n));
+    }
+    out.append(data);
+    return out;
+}
+
+QByteArray PskReporter::buildPacket(bool withTemplates)
+{
+    QByteArray packet;
+
+    // ---- Header (16 bytes) — length and seq filled in later ----
+    appendU16(packet, IPFIX_VERSION);
+    appendU16(packet, 0);                       // total length (patched)
+    appendU32(packet, static_cast<quint32>(QDateTime::currentSecsSinceEpoch()));
+    appendU32(packet, sequence_);
+    appendU32(packet, observationDomainId_);
+
+    // ---- Template set (only when needed) ----
+    if (withTemplates) {
+        QByteArray tset;
+        appendU16(tset, 2);          // set ID = template set
+        appendU16(tset, 0);          // set length (patched)
+
+        // Receiver template: 4 variable-length enterprise fields.
+        appendU16(tset, RECEIVER_TEMPLATE_ID);
+        appendU16(tset, 4);          // field count
+        appendFieldSpec(tset, IE_RECEIVER_CALLSIGN, 0xFFFF, PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_RECEIVER_LOCATOR,  0xFFFF, PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_RECEIVER_SOFTWARE, 0xFFFF, PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_RECEIVER_ANTENNA,  0xFFFF, PSK_ENTERPRISE_PEN);
+
+        // Sender template: callsign, grid, freq, snr, mode, time.
+        appendU16(tset, SENDER_TEMPLATE_ID);
+        appendU16(tset, 6);          // field count
+        appendFieldSpec(tset, IE_SENDER_CALLSIGN,  0xFFFF, PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_SENDER_LOCATOR,   0xFFFF, PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_SENDER_FREQUENCY, 4,      PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_SENDER_SNR,       1,      PSK_ENTERPRISE_PEN);
+        appendFieldSpec(tset, IE_SENDER_MODE,      0xFFFF, PSK_ENTERPRISE_PEN);
+        appendStandardFieldSpec(tset, IE_FLOW_START_SECONDS, 4);
+
+        padTo4(tset);
+        writeU16At(tset, 2, static_cast<quint16>(tset.size()));
+        packet.append(tset);
+    }
+
+    // ---- Receiver data set (one record describing this station) ----
+    {
+        QByteArray rset;
+        appendU16(rset, RECEIVER_TEMPLATE_ID);
+        appendU16(rset, 0);          // set length (patched)
+
+        QByteArray softwareTag = QString("wfweb %1")
+            .arg(QStringLiteral(WFWEB_VERSION)).toUtf8();
+
+        rset.append(encodeVarField(callsign_.toUtf8()));
+        rset.append(encodeVarField(grid_.toUtf8()));
+        rset.append(encodeVarField(softwareTag));
+        rset.append(encodeVarField(QByteArray()));  // antenna info — empty
+
+        padTo4(rset);
+        writeU16At(rset, 2, static_cast<quint16>(rset.size()));
+        packet.append(rset);
+    }
+
+    // ---- Sender data set (one record per spot) ----
+    if (!pendingSpots_.isEmpty()) {
+        QByteArray sset;
+        appendU16(sset, SENDER_TEMPLATE_ID);
+        appendU16(sset, 0);          // set length (patched)
+
+        for (const Spot &s : pendingSpots_) {
+            sset.append(encodeVarField(s.callsign.toUtf8()));
+            sset.append(encodeVarField(s.grid.toUtf8()));   // empty allowed
+            appendU32(sset, static_cast<quint32>(s.freq));
+            sset.append(static_cast<char>(static_cast<qint8>(s.snr)));
+            sset.append(encodeVarField(s.mode.toUtf8()));
+            appendU32(sset, static_cast<quint32>(s.timeSeconds));
+        }
+
+        padTo4(sset);
+        writeU16At(sset, 2, static_cast<quint16>(sset.size()));
+        packet.append(sset);
+    }
+
+    // Patch total message length.
+    writeU16At(packet, 2, static_cast<quint16>(packet.size()));
+    return packet;
+}
+
+void PskReporter::sendPacket()
+{
+    if (!dnsResolved_) return;
+
+    qint64 now = QDateTime::currentSecsSinceEpoch();
+    bool sendTemplates = (lastTemplateTime_ == 0)
+                         || (now - lastTemplateTime_ >= TEMPLATE_REFRESH_SECS);
+
+    QByteArray packet = buildPacket(sendTemplates);
+
+    qint64 written = socket_->writeDatagram(packet, serverAddr_, DEFAULT_PORT);
+    if (written < 0) {
+        qWarning() << "PskReporter: writeDatagram failed:" << socket_->errorString();
+        return;
+    }
+    qInfo() << "PskReporter: sent" << written << "bytes ("
+            << pendingSpots_.size() << "spots, templates="
+            << sendTemplates << ", seq=" << sequence_ << ")";
+
+    sequence_ += pendingSpots_.size() + 1;     // 1 receiver record + N spots
+    if (sendTemplates) lastTemplateTime_ = now;
+    pendingSpots_.clear();
+}

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -1401,6 +1401,9 @@ void webServer::disableFreeDV()
         freedvReporter->disconnectFromService();
         qInfo() << "Web: Reporter disconnected (FreeDV disabled)";
     }
+    // Reporter checkbox may still be on — flip the displayed state from
+    // "connected" to "waiting" so the UI stops looking active.
+    notifyFreedvReporterStatus();
     qInfo() << "Web: FreeDV disabled";
 }
 
@@ -1955,6 +1958,9 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
             // Reconnect reporter when entering FreeDV/RADE mode
             if (freedvEnabled && freedvReporter && reporterEnabled)
                 freedvReporter->connectToService();
+            // Even without a connect, flip "waiting" → "connecting" / "connected"
+            // (or back the other way for disable) for the UI right away.
+            notifyFreedvReporterStatus();
         } else {
             disableFreeDV();
         }
@@ -2384,8 +2390,14 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
     else if (type == "setReporter") {
         reporterCallsign = cmd["callsign"].toString().toUpper().trimmed();
         reporterGrid = cmd["grid"].toString().toUpper().trimmed();
-        reporterEnabled = cmd["enabled"].toBool();
+        // "enabled" is the legacy field (FreeDV reporter); "freedvEnabled"
+        // is the explicit name now that PSK Reporter is also configured here.
+        reporterEnabled = cmd.contains("freedvEnabled")
+                            ? cmd["freedvEnabled"].toBool()
+                            : cmd["enabled"].toBool();
+        bool wantPsk = cmd["pskEnabled"].toBool();
 
+        // ---- FreeDV Reporter ----
         if (reporterEnabled) {
             if (!freedvReporter) {
                 freedvReporter = new FreeDVReporter(this);
@@ -2413,6 +2425,36 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
             if (freedvReporter)
                 freedvReporter->disconnectFromService();
         }
+
+        // ---- PSK Reporter (FT8/FT4) ----
+        pskReporterEnabled = wantPsk;
+        if (pskReporterEnabled) {
+            if (!pskReporter) {
+                pskReporter = new PskReporter(this);
+                connect(pskReporter, &PskReporter::stateChanged,
+                        this, &webServer::onPskReporterStateChanged);
+            }
+            pskReporter->setStation(reporterCallsign, reporterGrid);
+
+            if (queue) {
+                vfoCommandType t = queue->getVfoCommand(vfoA, 0, false);
+                cacheItem freqCache = queue->getCache(t.freqFunc, 0);
+                if (freqCache.value.isValid()) {
+                    freqt f = freqCache.value.value<freqt>();
+                    if (f.Hz > 0) pskReporter->updateFrequency(f.Hz);
+                }
+            }
+
+            // Connect only if a digital mode panel (FT8/FT4) is currently active.
+            if (digiActive) {
+                pskReporter->updateTx(digiMode, false);
+                pskReporter->connectToService();
+            }
+        } else {
+            if (pskReporter)
+                pskReporter->disconnectFromService();
+        }
+
         // Pass callsign to RADE processor for EOO encoding
         if (radeProcessor && !reporterCallsign.isEmpty()) {
             QMetaObject::invokeMethod(radeProcessor, "setTxCallsign",
@@ -2420,11 +2462,43 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
                                       Q_ARG(QString, reporterCallsign));
         }
 
-        QJsonObject notify;
-        notify["type"] = "reporterStatus";
-        notify["enabled"] = reporterEnabled;
-        notify["state"] = freedvReporter ? (reporterEnabled ? "connecting" : "disconnected") : "disconnected";
-        sendJsonToAll(notify);
+        notifyFreedvReporterStatus();
+        notifyPskReporterStatus();
+    }
+    else if (type == "setDigiActive") {
+        // Browser opens / closes the FT8/FT4 panel.  PSK Reporter only
+        // connects while a digital mode is actually being decoded.
+        digiActive = cmd["active"].toBool();
+        QString m = cmd["mode"].toString().toUpper();
+        if (m == "FT8" || m == "FT4") digiMode = m;
+
+        if (pskReporter && pskReporterEnabled) {
+            if (digiActive) {
+                pskReporter->updateTx(digiMode, false);
+                pskReporter->connectToService();
+            } else {
+                // Flush whatever's queued before going dormant.
+                pskReporter->disconnectFromService();
+            }
+        }
+        // Even if no reporter object exists yet, the displayed state can flip
+        // between "waiting" and "disconnected" based on digiActive — refresh.
+        notifyPskReporterStatus();
+    }
+    else if (type == "reportDigiSpot") {
+        // Browser-side FT8/FT4 decode → forward to PSK Reporter.  The browser
+        // computes the on-air RF frequency (rig dial + audio offset) so the
+        // backend doesn't need to know the rig's USB/LSB sense.
+        if (pskReporter && pskReporterEnabled && digiActive) {
+            QString call = cmd["callsign"].toString().toUpper().trimmed();
+            QString grid = cmd["grid"].toString().toUpper().trimmed();
+            QString mode = cmd["mode"].toString().toUpper().trimmed();
+            if (mode != "FT8" && mode != "FT4") mode = digiMode;
+            int snr = cmd["snr"].toInt();
+            quint64 freqHz = cmd["freq"].toVariant().toULongLong();
+            if (freqHz > 0) pskReporter->updateFrequency(freqHz);
+            pskReporter->updateRxSpotWithGrid(call, grid, mode, snr);
+        }
     }
     else {
         qWarning() << "Web: Unknown command:" << type;
@@ -2641,10 +2715,15 @@ QJsonObject webServer::buildStatusJson()
 
     // Reporter
     status["reporterEnabled"] = reporterEnabled;
+    static const char *reporterStateNames[] = {"disconnected", "connecting", "connected", "error"};
     if (freedvReporter) {
-        static const char *stateNames[] = {"disconnected", "connecting", "connected", "error"};
         int s = static_cast<int>(freedvReporter->state());
-        status["reporterState"] = QString(stateNames[qBound(0, s, 3)]);
+        status["reporterState"] = QString(reporterStateNames[qBound(0, s, 3)]);
+    }
+    status["pskReporterEnabled"] = pskReporterEnabled;
+    if (pskReporter) {
+        int s = static_cast<int>(pskReporter->state());
+        status["pskReporterState"] = QString(reporterStateNames[qBound(0, s, 3)]);
     }
 
     // AF Gain
@@ -2762,6 +2841,7 @@ void webServer::receiveCache(cacheItem item)
         freqt f = item.value.value<freqt>();
         update["frequency"] = (qint64)f.Hz;
         if (freedvReporter) freedvReporter->updateFrequency(f.Hz);
+        if (pskReporter) pskReporter->updateFrequency(f.Hz);
         break;
     }
     case funcMode:
@@ -3538,21 +3618,52 @@ void webServer::onFreeDVRxCallsign(const QString &callsign)
         freedvReporter->updateRxSpot(callsign, freedvModeName, (int)freedvSNR);
 }
 
-void webServer::onReporterStateChanged(int state)
+// "waiting" replaces "connecting" when a reporter is enabled but the
+// matching mode (FreeDV or FT8/FT4) is not currently active — there is
+// nothing to connect to yet, so saying "connecting" would be misleading.
+static QString reporterDisplayState(SpotReporter::State s, bool enabled, bool modeActive)
 {
-    QString stateStr;
-    switch (static_cast<SpotReporter::State>(state)) {
-    case SpotReporter::Disconnected: stateStr = "disconnected"; break;
-    case SpotReporter::Connecting:   stateStr = "connecting";   break;
-    case SpotReporter::Connected:    stateStr = "connected";    break;
-    case SpotReporter::Error:        stateStr = "error";        break;
+    if (!enabled) return QStringLiteral("disconnected");
+    if (!modeActive) return QStringLiteral("waiting");
+    switch (s) {
+    case SpotReporter::Disconnected: return QStringLiteral("disconnected");
+    case SpotReporter::Connecting:   return QStringLiteral("connecting");
+    case SpotReporter::Connected:    return QStringLiteral("connected");
+    case SpotReporter::Error:        return QStringLiteral("error");
     }
+    return QStringLiteral("disconnected");
+}
 
+void webServer::notifyFreedvReporterStatus()
+{
+    SpotReporter::State s = freedvReporter ? freedvReporter->state()
+                                           : SpotReporter::Disconnected;
     QJsonObject notify;
     notify["type"] = "reporterStatus";
     notify["enabled"] = reporterEnabled;
-    notify["state"] = stateStr;
+    notify["state"] = reporterDisplayState(s, reporterEnabled, freedvEnabled);
     sendJsonToAll(notify);
+}
+
+void webServer::notifyPskReporterStatus()
+{
+    SpotReporter::State s = pskReporter ? pskReporter->state()
+                                        : SpotReporter::Disconnected;
+    QJsonObject notify;
+    notify["type"] = "pskReporterStatus";
+    notify["enabled"] = pskReporterEnabled;
+    notify["state"] = reporterDisplayState(s, pskReporterEnabled, digiActive);
+    sendJsonToAll(notify);
+}
+
+void webServer::onReporterStateChanged(int /*state*/)
+{
+    notifyFreedvReporterStatus();
+}
+
+void webServer::onPskReporterStateChanged(int /*state*/)
+{
+    notifyPskReporterStatus();
 }
 
 void webServer::startReporterSnrTimer()

--- a/wfweb.pro
+++ b/wfweb.pro
@@ -237,8 +237,8 @@ win32 {
     }
     LIBS += -lcodec2
 }
-SOURCES += src/freedvprocessor.cpp src/freedvreporter.cpp
-HEADERS += include/freedvprocessor.h include/freedvreporter.h include/spotreporter.h
+SOURCES += src/freedvprocessor.cpp src/freedvreporter.cpp src/pskreporter.cpp
+HEADERS += include/freedvprocessor.h include/freedvreporter.h include/pskreporter.h include/spotreporter.h
 message("FreeDV codec2 support enabled")
 
 # Dire Wolf packet modem (AX.25 / APRS) — always built.


### PR DESCRIPTION
PskReporter speaks IPFIX over UDP to report.pskreporter.info:4739, buffers spots for ~5 minutes between flushes, and reports the same shared callsign / grid as the FreeDV Reporter.  Mirrors the SpotReporter base interface so it slots in next to FreeDVReporter.

Backend wiring: setReporter now carries both freedvEnabled and pskEnabled (legacy "enabled" still accepted); new setDigiActive and reportDigiSpot commands let the browser tell the backend when the FT8/FT4 panel is open and forward each decode's callsign / grid / SNR / RF freq.

Web UI: a second "pskreporter.info Reporter (FT8/FT4)" checkbox sits under the existing FreeDV Reporter toggle in Station Settings, with its own status span.  Both checkboxes persist via localStorage.

Status text: enabling a reporter while the matching mode is inactive now shows "waiting for FreeDV" / "waiting for FT8/FT4" in amber instead of a misleading "connecting".