### PR TITLE
CI/Windows: bundle MinGW runtime DLLs for libcodec2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -570,6 +570,13 @@ jobs:
             if (Test-Path $src) { Copy-Item $src $out -Force }
           }
 
+          # MinGW runtime DLLs required by libcodec2.dll (built via MSYS2 MinGW)
+          $mingwBin = "C:\msys64\mingw64\bin"
+          foreach ($dll in @("libgcc_s_seh-1.dll", "libstdc++-6.dll", "libwinpthread-1.dll")) {
+            $src = Join-Path $mingwBin $dll
+            if (Test-Path $src) { Copy-Item $src $out -Force }
+          }
+
           # OpenSSL 1.1 aliases for Qt 5.15
           if (!(Test-Path "$out\libssl-1_1-x64.dll") -and (Test-Path "$out\libssl-3-x64.dll")) {
             Copy-Item "$out\libssl-3-x64.dll" "$out\libssl-1_1-x64.dll"


### PR DESCRIPTION
libcodec2.dll is built with MSYS2 MinGW GCC and depends on libgcc_s_seh-1.dll, libstdc++-6.dll, and libwinpthread-1.dll, which were not shipped in the release zip. Users had to copy them from WSJT-X to launch wfweb.exe.

Fixes #42