### PR TITLE
Fix #51: APRS Heard Stations empty on USB audio path

### DIFF
--- a/resources/web/packet.js
+++ b/resources/web/packet.js
@@ -1086,8 +1086,33 @@
     }
 
     function aprsClearStations() {
-        if (!confirm('Forget all heard APRS stations?')) return;
-        if (window.send) window.send({ cmd: 'aprsClearStations' });
+        var existing = document.getElementById('aprsClearConfirm');
+        if (existing) existing.remove();
+
+        var modal = document.createElement('div');
+        modal.id = 'aprsClearConfirm';
+        modal.className = 'term-file-prompt';
+        modal.innerHTML =
+            '<div class="term-file-prompt-box">' +
+                '<div class="term-file-prompt-title">Forget heard stations?</div>' +
+                '<div class="term-file-prompt-body">' +
+                    'This will clear the APRS heard-stations list.' +
+                '</div>' +
+                '<div class="term-file-prompt-note">Stations will reappear as they are heard again.</div>' +
+                '<div class="term-file-prompt-btns">' +
+                    '<button id="aprsClearCancel" class="packet-action-btn">Cancel</button>' +
+                    '<button id="aprsClearOk" class="packet-action-btn term-xfer-abort">Forget all</button>' +
+                '</div>' +
+            '</div>';
+        document.body.appendChild(modal);
+        document.getElementById('aprsClearCancel').onclick = function() { modal.remove(); };
+        document.getElementById('aprsClearOk').onclick = function() {
+            if (window.send) window.send({ cmd: 'aprsClearStations' });
+            modal.remove();
+        };
+        modal.addEventListener('click', function(e) {
+            if (e.target === modal) modal.remove();
+        });
     }
 
     function renderAprsBeaconButton() {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -5238,6 +5238,21 @@ void webServer::setupUsbAudio(quint32 sampleRate)
                 Qt::QueuedConnection);
         axProc->start();
 
+        // APRS layer.  Mirrors the LAN-audio path in setupAudio(): without
+        // this the USB capture path decodes UI frames into the Monitor view
+        // but the Heard Stations list never populates because nothing is
+        // listening on rxFrameDecoded for parsing.
+        aprsProc = new AprsProcessor(this);
+        connect(dwProc, &DireWolfProcessor::rxFrameDecoded,
+                aprsProc, &AprsProcessor::onRxFrame,
+                Qt::QueuedConnection);
+        connect(aprsProc, &AprsProcessor::stationUpdated,
+                this, &webServer::onAprsStationUpdated);
+        connect(aprsProc, &AprsProcessor::stationsCleared,
+                this, &webServer::onAprsStationsCleared);
+        connect(aprsProc, &AprsProcessor::txBeaconRequested,
+                this, &webServer::onAprsBeaconRequested);
+
         // Load persisted enable/mode state, then apply it to the processors
         // and broadcast a packetStatus so the UI picks up the restored value.
         packetLoadSettings();


### PR DESCRIPTION
## Summary
- Wire `AprsProcessor` into the USB audio capture path in `webServer::setupUsbAudio()` so the Heard Stations list populates when the modem runs over USB (the LAN path was already covered).
- Replace the blocking `confirm()` for "Forget all heard APRS stations" with a non-blocking overlay modeled on the existing `term-file-prompt` style, for visual consistency with the other in-app dialogs.

## Test plan
- [ ] With USB audio routing, decode a few APRS UI frames and verify they appear in the Heard Stations list (was empty before fix).
- [ ] Click **Clear** in the APRS panel, confirm the new overlay appears (no native browser dialog).
- [ ] Confirm overlay: cancel button dismisses; "Forget all" sends `aprsClearStations` and the list clears; clicking the dimmed background dismisses.
- [ ] Regression-check the LAN audio path still populates Heard Stations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)