### PR TITLE
fix(release): move WFWEB_VERSION into a header so bumps actually rebuild

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -7,8 +7,15 @@ Steps:
    - Add a new section at the top with the version number and today's date
    - Categorize commits into user-facing sections (Features, Fixes, etc.)
    - Do NOT include internal/CI-only changes unless significant
-4. Update the version in `wfweb.pro` (look for `DEFINES += WFWEB_VERSION=\"X.Y.Z\"` on line ~18)
-5. Build to verify: `qmake wfweb.pro && make -j$(nproc)`
+4. Update the version in `include/wfweb_version.h` (look for `#define WFWEB_VERSION "X.Y.Z"`).
+   This is the single source of truth — `tools/build-static.sh` and the GitHub
+   Actions workflows grep this file for the version. Do NOT add a `WFWEB_VERSION`
+   DEFINE to `wfweb.pro`: that path silently produced stale binaries in v0.7.1
+   because Make doesn't track `-D` flag changes (see commit history).
+5. Build to verify: `qmake wfweb.pro && make -j$(nproc)`. Then run
+   `./wfweb --version` and confirm every reported version is the new one.
+   Optional belt-and-suspenders: `make clean && qmake && make` — only needed
+   if you suspect stale objects from before this header existed.
 6. Show the user the CHANGELOG diff and version change for review before committing
 
 CRITICAL: Always update CHANGELOG BEFORE bumping the version. Never skip the CHANGELOG.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(grep 'WFWEB_VERSION' wfweb.pro | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep '#define WFWEB_VERSION' include/wfweb_version.h | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
 
       - name: Build .deb
         run: |
@@ -196,7 +196,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(grep 'WFWEB_VERSION' wfweb.pro | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep '#define WFWEB_VERSION' include/wfweb_version.h | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
 
       - name: Build .deb
         run: |
@@ -324,7 +324,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(grep 'WFWEB_VERSION' wfweb.pro | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep '#define WFWEB_VERSION' include/wfweb_version.h | grep -oP '[\d.]+')" >> $GITHUB_OUTPUT
 
       - name: Build .deb
         run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ a built-in web interface. See https://gitlab.com/eliggett/wfview for the
 upstream wfview history.
 
 
-[unreleased]
+v0.7.2 (2026-05-08)
 --------------------
 
 Server build:
@@ -17,6 +17,15 @@ Server build:
   so RADE EOO synthesis, packet TX gating and ALC meter polling stay
   coherent. Default bind is `127.0.0.1`; pass `--rigctld-bind-all` to listen
   on all interfaces (the Hamlib protocol is unauthenticated). (#64)
+
+Fixes:
+- FreeDV Reporter (and PSK Reporter) no longer announce a stale version
+  string after a version bump. The version moved from a `-D` flag in
+  `wfweb.pro` to `include/wfweb_version.h`, which Make's header-dependency
+  tracking actually picks up. Previously, bumping only `wfweb.pro` left
+  `freedvreporter.o` and `pskreporter.o` compiled against the old version
+  while other objects rebuilt — so the splash showed the new number but
+  the reporter advertised the old one. Affected v0.7.1 in the wild. (#65)
 
 
 v0.7.1 (2026-05-03)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,10 @@ Server build:
   on all interfaces (the Hamlib protocol is unauthenticated). (#64)
 
 Fixes:
+- CW decoder now stops when leaving CW mode. Previously the worker,
+  AudioWorklet, and audio graph stayed wired up after switching to SSB,
+  so the decoder kept consuming audio and logging detections forever.
+  Applies to both server and standalone builds. (#63)
 - FreeDV Reporter (and PSK Reporter) no longer announce a stale version
   string after a version bump. The version moved from a `-D` flag in
   `wfweb.pro` to `include/wfweb_version.h`, which Make's header-dependency

--- a/include/wfweb_version.h
+++ b/include/wfweb_version.h
@@ -1,0 +1,19 @@
+#ifndef WFWEB_VERSION_H
+#define WFWEB_VERSION_H
+
+// Single source of truth for the wfweb version.
+//
+// Defined here as a header (not as a -D flag in wfweb.pro) so that Make's
+// header-dependency tracking forces a rebuild of every file that embeds the
+// version string when this file changes. With -D, qmake's Makefile only
+// reflects the new flag in compile commands, but Make does not rerun those
+// commands unless the .cpp/.h mtimes change — which leaves stale .o files
+// with the old version baked in. See v0.7.1, where freedvreporter.o kept
+// reporting "0.7.0" after a version bump that touched only wfweb.pro.
+//
+// tools/build-static.sh and .github/workflows/build.yml grep this file for
+// the version, so keep the line format stable.
+
+#define WFWEB_VERSION "0.7.2"
+
+#endif // WFWEB_VERSION_H

--- a/src/freedvreporter.cpp
+++ b/src/freedvreporter.cpp
@@ -1,5 +1,6 @@
 #include "freedvreporter.h"
 #include "logcategories.h"
+#include "wfweb_version.h"
 
 #include <QJsonDocument>
 #include <QJsonArray>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <QTranslator>
 #endif
 
+#include "wfweb_version.h"
+
 #ifdef Q_OS_WIN
 #include <windows.h>
 #include <atomic>

--- a/src/pskreporter.cpp
+++ b/src/pskreporter.cpp
@@ -1,5 +1,6 @@
 #include "pskreporter.h"
 #include "logcategories.h"
+#include "wfweb_version.h"
 
 #include <QDataStream>
 #include <QDateTime>

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -2,6 +2,7 @@
 #include "freedvprocessor.h"
 #include <codec2/freedv_api.h>
 #include "logcategories.h"
+#include "wfweb_version.h"
 
 #include <QStandardPaths>
 #include <QDir>

--- a/tools/build-static.sh
+++ b/tools/build-static.sh
@@ -140,12 +140,12 @@ Opera, Brave, Arc). Firefox / Safari users can't use this build.
 - Non-Chromium browsers (Firefox, Safari, …)
 EOF
 
-# Single source of truth for the user-facing version: wfweb.pro. Server
-# (C++) reads it via the WFWEB_VERSION DEFINE; Standalone reads it here so
-# both builds report the same number.
-WFWEB_SEMVER="$(grep -E 'WFWEB_VERSION' "$REPO_ROOT/wfweb.pro" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+# Single source of truth for the user-facing version: include/wfweb_version.h.
+# Server (C++) reads it via #include; Standalone reads it here so both builds
+# report the same number.
+WFWEB_SEMVER="$(grep -E '#define WFWEB_VERSION' "$REPO_ROOT/include/wfweb_version.h" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 if [ -z "$WFWEB_SEMVER" ]; then
-    echo "ERROR: could not extract WFWEB_VERSION from $REPO_ROOT/wfweb.pro" >&2
+    echo "ERROR: could not extract WFWEB_VERSION from $REPO_ROOT/include/wfweb_version.h" >&2
     exit 1
 fi
 

--- a/wfweb.pro
+++ b/wfweb.pro
@@ -15,7 +15,8 @@ macx:CONFIG -= app_bundle
 macx:CONFIG += c++17
 win32:CONFIG += c++17
 
-DEFINES += WFWEB_VERSION=\\\"0.7.1\\\"
+# WFWEB_VERSION lives in include/wfweb_version.h so header-dep tracking
+# forces a rebuild of every consumer on bump. Do NOT add a -D for it here.
 
 DEFINES += BUILD_WFSERVER
 
@@ -372,6 +373,7 @@ macx:SOURCES += src/tlsproxy.cpp
 
 
 HEADERS  += \
+    include/wfweb_version.h \
     include/servermain.h \
     src/audio/adpcm/adpcm-lib.h \
     src/audio/resampler/resample_neon.h \


### PR DESCRIPTION
## Summary

- Move \`WFWEB_VERSION\` from a \`-D\` flag in \`wfweb.pro\` to \`include/wfweb_version.h\`, and add it to \`HEADERS\` so qmake emits a real dependency. Make's header-dep tracking now forces a rebuild of every consumer when the version is bumped.
- Bumps to **v0.7.2** to ship a binary where the version is self-consistent across the splash, \`--version\`, FreeDV Reporter auth, and PSK Reporter spots.

## Why

v0.7.1 was a \`DEFINES\`-only change. Make tracks file mtimes, not compiler flags, so \`make\` after the bump rebuilt nothing — except for files whose mtimes happened to change for unrelated reasons. Result: \`webserver.o\` / \`main.o\` were rebuilt with WFWEB_VERSION=\"0.7.1\" while \`freedvreporter.o\` / \`pskreporter.o\` stayed compiled against \"0.7.0\". The splash showed v0.7.1 but the FreeDV Reporter session announced \`wfweb 0.7.0\`. \`strings -e l freedvreporter.o\` confirmed the stale UTF-16 literal in the .o.

## Changes

- New: \`include/wfweb_version.h\` — single source of truth, named \`wfweb_version.h\` (not \`version.h\`) because \`resources/direwolf/src/version.h\` sits earlier on the include path and would shadow ours.
- \`wfweb.pro\`: drops the \`WFWEB_VERSION\` \`DEFINES\` line; adds the new header to \`HEADERS\`.
- \`src/{freedvreporter,webserver,pskreporter,main}.cpp\`: \`#include \"wfweb_version.h\"\`.
- \`tools/build-static.sh\` and \`.github/workflows/build.yml\` (3 grep sites): read the version from the header instead of \`wfweb.pro\`.
- \`.claude/commands/release.md\`: release flow now edits the header, with a back-reference to the v0.7.1 incident.
- \`CHANGELOG\`: v0.7.2 entry.

## Test plan

- [x] Clean rebuild (\`make clean && qmake && make\`) succeeds
- [x] \`./wfweb --version\` reports \`0.7.2\`
- [x] Every \`0.7.x\` literal in the binary is \`0.7.2\` (verified across \`strings -e {s,b,l,B,L}\` encodings — no stale 0.7.0 / 0.7.1 anywhere)
- [x] Header-dep tracking works: \`touch include/wfweb_version.h && make\` triggers rebuild of the four consumers and relinks \`wfweb\`
- [x] Both grep patterns (\`tools/build-static.sh\`, \`.github/workflows/build.yml\`) extract \`0.7.2\` from the header
- [ ] Confirm in real session that FreeDV Reporter announces \`wfweb 0.7.2\` (requires running build against qso.freedv.org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)