### PR TITLE
fix(standalone+server): stop CW decoder when leaving CW mode

### DIFF
--- a/resources/web-standalone/index.html
+++ b/resources/web-standalone/index.html
@@ -3390,6 +3390,13 @@ function updateMode(mode) {
     if (!isCW) {
         document.getElementById('cwBar').classList.add('hidden');
         cwBarSuspended = false;
+        // Symmetric to autoOpenCwBarOnModeEntry — without this the
+        // decoder worker keeps consuming audio and logging detections
+        // forever after the user leaves CW.
+        var decodeBtn = document.getElementById('cwDecoderToggle');
+        if (decodeBtn && decodeBtn.classList.contains('active')) {
+            decodeBtn.click();
+        }
     } else if (!wasCW) {
         autoOpenCwBarOnModeEntry();
     }

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -3040,6 +3040,13 @@ function updateMode(mode) {
     if (!isCW) {
         document.getElementById('cwBar').classList.add('hidden');
         cwBarSuspended = false;
+        // Symmetric to autoOpenCwBarOnModeEntry — without this the
+        // decoder worker keeps consuming audio and logging detections
+        // forever after the user leaves CW.
+        var decodeBtn = document.getElementById('cwDecoderToggle');
+        if (decodeBtn && decodeBtn.classList.contains('active')) {
+            decodeBtn.click();
+        }
     } else if (!wasCW) {
         autoOpenCwBarOnModeEntry();
     }


### PR DESCRIPTION
## Summary

- Fixes #63. Switching out of CW into SSB (or any non-CW mode) hid the CW bar but left the decoder pipeline running — the worker, AudioWorklet, and audio graph stayed wired up and the console kept printing detected freq/WPM forever.
- `updateMode()` already auto-opens the bar on CW entry; mirror that on exit by clicking `cwDecoderToggle` off when it's active, so `stopDecoder()` actually tears the pipeline down.
- Applied to both `index.html` forks (server build and standalone) since they share this code path.

## Test plan

- [ ] Server build: enable CW decoder, switch from CW to SSB, confirm the worker stops (no further detection logs)
- [ ] Standalone build: same flow against a real Icom or virtual rig
- [ ] Re-entering CW after the auto-stop still auto-opens the bar cleanly (sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)