### PR TITLE
Waterfall Dragging Snap to 100hz and Browser Full Screen

### DIFF
--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -1844,6 +1844,7 @@ body.digi-open #bottomBar { grid-row: 5; }
         <span class="flex-space"></span>
         <button id="qsoLogBtn" class="qso-log-btn" title="Log QSO">LOG</button>
         <span id="clock">--:--</span>
+        <button id="fullscreenBtn" title="Full Screen" onclick="toggleFullscreen()">&#x26F6;</button>
         <button id="powerBtn" class="on" title="Power" onclick="togglePower()">&#x23FB;</button>
         <span id="connDot" title="Disconnected"></span>
     </div>
@@ -4736,6 +4737,14 @@ function updateFreeDVStatus(msg) {
     if (currentPanel === 'func') renderFuncOverlay();
 }
 
+function toggleFullscreen() {
+    if (!document.fullscreenElement) {
+        document.documentElement.requestFullscreen();
+    } else {
+        document.exitFullscreen();
+    }
+}
+
 function tuneUp() {
     if (currentFreq > 0) {
         var newFreq = currentFreq + tuneStep;
@@ -5265,24 +5274,13 @@ function scopeGesturesBlocked() {
     return isMobilePortrait && !document.getElementById('cwBar').classList.contains('hidden');
 }
 
-const SCOPE_TUNE_STEP_HZ = 100;
-
-function snapScopeFrequency(freqHz) {
-    return Math.max(
-        SCOPE_TUNE_STEP_HZ,
-        Math.round(freqHz / SCOPE_TUNE_STEP_HZ) * SCOPE_TUNE_STEP_HZ
-    );
-}
-
 function scopeFreqFromClientX(target, clientX) {
     if (!target || spectStartFreq <= 0 || spectEndFreq <= spectStartFreq) return 0;
     var rect = target.getBoundingClientRect();
     if (rect.width <= 0) return 0;
     var frac = (clientX - rect.left) / rect.width;
     frac = Math.max(0, Math.min(1, frac));
-    return snapScopeFrequency(
-        (spectStartFreq + (spectEndFreq - spectStartFreq) * frac) * 1e6
-    );
+    return Math.round((spectStartFreq + (spectEndFreq - spectStartFreq) * frac) * 1e6);
 }
 
 function scopeSetVisualPan(px) {
@@ -5302,7 +5300,7 @@ function scopeFreqFromDragDeltaX(deltaX) {
     var spanHz = (spectEndFreq - spectStartFreq) * 1e6;
     var hzPerPx = spanHz / scopeDragRectWidth;
     // Left pan (negative deltaX) should increase frequency.
-    return snapScopeFrequency(scopeDragStartFreq - deltaX * hzPerPx);
+    return Math.max(100, Math.round((scopeDragStartFreq - deltaX * hzPerPx) / 100) * 100);
 }
 
 function scopeIndicatorCenterX(w) {

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -5265,13 +5265,24 @@ function scopeGesturesBlocked() {
     return isMobilePortrait && !document.getElementById('cwBar').classList.contains('hidden');
 }
 
+const SCOPE_TUNE_STEP_HZ = 100;
+
+function snapScopeFrequency(freqHz) {
+    return Math.max(
+        SCOPE_TUNE_STEP_HZ,
+        Math.round(freqHz / SCOPE_TUNE_STEP_HZ) * SCOPE_TUNE_STEP_HZ
+    );
+}
+
 function scopeFreqFromClientX(target, clientX) {
     if (!target || spectStartFreq <= 0 || spectEndFreq <= spectStartFreq) return 0;
     var rect = target.getBoundingClientRect();
     if (rect.width <= 0) return 0;
     var frac = (clientX - rect.left) / rect.width;
     frac = Math.max(0, Math.min(1, frac));
-    return Math.round((spectStartFreq + (spectEndFreq - spectStartFreq) * frac) * 1e6);
+    return snapScopeFrequency(
+        (spectStartFreq + (spectEndFreq - spectStartFreq) * frac) * 1e6
+    );
 }
 
 function scopeSetVisualPan(px) {
@@ -5291,7 +5302,7 @@ function scopeFreqFromDragDeltaX(deltaX) {
     var spanHz = (spectEndFreq - spectStartFreq) * 1e6;
     var hzPerPx = spanHz / scopeDragRectWidth;
     // Left pan (negative deltaX) should increase frequency.
-    return Math.max(1, Math.round(scopeDragStartFreq - deltaX * hzPerPx));
+    return snapScopeFrequency(scopeDragStartFreq - deltaX * hzPerPx);
 }
 
 function scopeIndicatorCenterX(w) {


### PR DESCRIPTION
## Proposed Changes

### Waterfall Dragging Snap

Out of the box, the dragging of WFWEB's waterfall display has a resolution of 1Hz. This makes it difficult to properly dial in a frequency without manually inputting the exact frequency. Setting a snap to 100Hz allows tuning to a proper frequency without having to secondarily enter the frequency you are attempting to tune to. 

This PR adds a snap to 100Hz for the waterfall dragging functionality, creating a better experience while dragging the waterfall to an active frequency. 

### Full Screen View

On mobile devices, the title bar of most browsers takes up valuable real estate. and tends to cut off some of the lower function buttons. Firefox Mobile unfortunately does not offer a full screen option natively, but a web application itself can request it.

This PR introduces a Fulle Screen icon (button) just to the left of the power icon to toggle full screen of the UI. The UI looks much cleaner in full screen and more closely replicates the display on the physical radio. 

#### Default Portrait View:
<img height="720" alt="portrait_default" src="https://github.com/user-attachments/assets/2dc50711-8ba4-4985-aaf8-3bc255edac6a" />

#### Full Screen Portrait View:
<img height="720" alt="portrait_full" src="https://github.com/user-attachments/assets/e4c6d831-9621-48db-b7c6-8dfd30771948" />

#### Default Landscape View:
<img width="720" alt="landscape_default" src="https://github.com/user-attachments/assets/072cfb62-6f9a-4567-a0c5-e44694a59d53" />

#### Full Screen Landscape View:
<img width="720" alt="landscape_full" src="https://github.com/user-attachments/assets/a0507198-1fe6-4774-84d2-a82d94643024" />

## Testing

- [x] Compiles for ARM64 and AMD64
- [X] Tested with Firefox Mobile on Android
- [X] Tested with Microsoft Edge

## Related

- [ ] Closes #85 