### PR TITLE
fix(memory): read correct memory group for IC-9700 instead of hardcoded group 0

### DIFF
--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -2455,8 +2455,9 @@ var availableAntennas = [];   // [{num, name}] — empty on single-antenna rigs 
 var hasRxAnt = false;         // rig has an RX-antenna input (IC-7610/785x)
 var currentAntenna = 0;
 var rxAntOn = false;
-var currentVfo = 'A';
+var currentVfo = 'A';        // 'A' | 'B' | 'MEM'
 var hasMainSub = false;
+var hasMemories = false;      // rig exposes memory channels
 
 // Meter state
 var meterVal = -54;
@@ -2645,6 +2646,7 @@ function handleMessage(msg) {
                 if (msg.filters) populateFilters(msg.filters);
                 if (msg.hasFilterSettings !== undefined) updateHasFilterSettings(msg.hasFilterSettings);
                 if (msg.hasMainSub !== undefined) { hasMainSub = msg.hasMainSub; updateVfoDisplay(); }
+                if (msg.hasMemories !== undefined) hasMemories = !!msg.hasMemories;
                 if (msg.memGroups !== undefined) setupMemoryGroups(msg.memGroups, msg.memStart || 0);
 
                 updateWarningVisibility();
@@ -2669,6 +2671,7 @@ function handleMessage(msg) {
             if (msg.filters) populateFilters(msg.filters);
             if (msg.hasFilterSettings !== undefined) updateHasFilterSettings(msg.hasFilterSettings);
             if (msg.hasMainSub !== undefined) { hasMainSub = msg.hasMainSub; updateVfoDisplay(); }
+            if (msg.hasMemories !== undefined) hasMemories = !!msg.hasMemories;
             if (msg.memGroups !== undefined) setupMemoryGroups(msg.memGroups, msg.memStart || 0);
             if (msg.hasPowerControl) document.getElementById('powerBtn').style.display = 'flex';
             if (msg.freedvModes) freedvModes = msg.freedvModes;
@@ -2845,10 +2848,11 @@ function updateFrequency(hz) {
         }
     }
 
-    // Store frequency for current VFO only
+    // Store frequency for current VFO only (not in memory mode — the recalled
+    // channel's freq must not overwrite either VFO's cached value)
     if (currentVfo === 'A') {
         vfoAFreq = hz;
-    } else {
+    } else if (currentVfo === 'B') {
         vfoBFreq = hz;
     }
 
@@ -2895,7 +2899,7 @@ function updateOtherVfoDisplay() {
 function applyVfoFreqMessage(msg) {
     if (msg.vfoAFrequency !== undefined) vfoAFreq = msg.vfoAFrequency;
     if (msg.vfoBFrequency !== undefined) vfoBFreq = msg.vfoBFrequency;
-    if (msg.selectedVfo === 'A' || msg.selectedVfo === 'B') {
+    if (msg.selectedVfo === 'A' || msg.selectedVfo === 'B' || msg.selectedVfo === 'MEM') {
         if (currentVfo !== msg.selectedVfo) {
             currentVfo = msg.selectedVfo;
             updateVfoDisplay();
@@ -2903,7 +2907,11 @@ function applyVfoFreqMessage(msg) {
         }
     }
     var hasVfoFreq = (msg.vfoAFrequency !== undefined || msg.vfoBFrequency !== undefined);
-    if (hasVfoFreq) {
+    if (currentVfo === 'MEM') {
+        // In memory mode the operating frequency is the recalled channel's,
+        // reported as msg.frequency — not either VFO cache slot.
+        if (msg.frequency !== undefined) updateFrequency(msg.frequency);
+    } else if (hasVfoFreq) {
         var ownFreq = (currentVfo === 'A') ? vfoAFreq : vfoBFreq;
         if (ownFreq > 0) updateFrequency(ownFreq);
         else updateOtherVfoDisplay();
@@ -4249,9 +4257,13 @@ function renderMemoryList() {
             });
             row.addEventListener('click', function() {
                 // Recall on the radio so it restores tone / tone squelch /
-                // duplex offset from the channel — not just freq + mode.
+                // duplex offset from the channel — not just freq + mode. The
+                // radio also switches to memory mode (front-panel V/M).
                 send({ cmd: 'recallMemory', channel: m.channel, group: m.group || 0,
                        frequency: m.frequency || 0, mode: m.mode || '' });
+                currentVfo = 'MEM';
+                updateVfoDisplay();
+                renderBottomBar();
                 setPanel('default');
             });
         })(mem);
@@ -4489,7 +4501,9 @@ function setMode(mode) {
 function updateVfoDisplay() {
     var label = document.getElementById('vfoLabel');
     var num = document.getElementById('vfoNum');
-    if (hasMainSub) {
+    if (currentVfo === 'MEM') {
+        label.textContent = 'MEM';
+    } else if (hasMainSub) {
         label.textContent = 'VFO ' + (currentVfo === 'A' ? 'MAIN' : 'SUB');
     } else {
         label.textContent = 'VFO ' + currentVfo;
@@ -4502,6 +4516,9 @@ function selectVFO(vfo) {
     currentVfo = vfo;
     updateVfoDisplay();
     renderBottomBar();
+    // Memory mode: leave the frequency display for the radio's round-trip
+    // (the recalled channel's freq), don't force a VFO-cache value.
+    if (vfo === 'MEM') return;
     // Reflect the new VFO's cached freq on the main display immediately so
     // the label and frequency stay in sync without waiting for the radio's
     // round-trip response. The server will follow up with fresh values.
@@ -5562,7 +5579,11 @@ document.getElementById('freqDisplay').addEventListener('click', function() {
 });
 
 document.getElementById('vfoLabel').addEventListener('click', function() {
-    selectVFO(currentVfo === 'A' ? 'B' : 'A');
+    // Cycle the operating mode: A -> B -> MEM -> A (MEM only if the rig has
+    // memory channels). Mirrors the front-panel A/B and V/M buttons.
+    var order = hasMemories ? ['A', 'B', 'MEM'] : ['A', 'B'];
+    var i = order.indexOf(currentVfo);
+    selectVFO(order[(i + 1) % order.length]);
 });
 
 

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -1472,6 +1472,11 @@ body.digi-open #bottomBar { grid-row: 5; }
 }
 .mem-modal-title span { flex: 1; }
 #memScanStatus { font-size: 0.8em; color: #448; margin-left: 8px; font-weight: normal; }
+#memGroupRow { font-size: 0.85em; margin: 0 8px; align-items: center; gap: 4px; }
+#memGroupSelect {
+    background: #001828; border: 1px solid #048; color: #8cf;
+    font-family: 'Courier New', monospace; font-size: 11px; padding: 1px 4px; border-radius: 3px;
+}
 .memory-list {
     overflow-y: auto;
     flex: 1;
@@ -1915,6 +1920,10 @@ body.digi-open #bottomBar { grid-row: 5; }
         <div id="memoryOverlay" class="mem-modal">
             <div class="mem-modal-title">
                 <span>Memories <span id="memScanStatus"></span></span>
+                <span id="memGroupRow" style="display:none;flex:0 0 auto;font-weight:normal;">
+                    <label for="memGroupSelect" style="color:#448;">Group</label>
+                    <select id="memGroupSelect" onchange="onMemGroupChange()"></select>
+                </span>
                 <button class="digi-settings-close" style="width:auto;margin:0;padding:2px 12px" onclick="closeMemoryModal()">&#x2715; Close</button>
             </div>
             <div class="memory-list">
@@ -2636,6 +2645,7 @@ function handleMessage(msg) {
                 if (msg.filters) populateFilters(msg.filters);
                 if (msg.hasFilterSettings !== undefined) updateHasFilterSettings(msg.hasFilterSettings);
                 if (msg.hasMainSub !== undefined) { hasMainSub = msg.hasMainSub; updateVfoDisplay(); }
+                if (msg.memGroups !== undefined) setupMemoryGroups(msg.memGroups, msg.memStart || 0);
 
                 updateWarningVisibility();
                 applyUrlTune();
@@ -2659,6 +2669,7 @@ function handleMessage(msg) {
             if (msg.filters) populateFilters(msg.filters);
             if (msg.hasFilterSettings !== undefined) updateHasFilterSettings(msg.hasFilterSettings);
             if (msg.hasMainSub !== undefined) { hasMainSub = msg.hasMainSub; updateVfoDisplay(); }
+            if (msg.memGroups !== undefined) setupMemoryGroups(msg.memGroups, msg.memStart || 0);
             if (msg.hasPowerControl) document.getElementById('powerBtn').style.display = 'flex';
             if (msg.freedvModes) freedvModes = msg.freedvModes;
             updateWarningVisibility();
@@ -4151,6 +4162,38 @@ function renderSpanOverlay() {
 
 // --- Memory overlay ---
 var memoryChannels = {};
+var memGroupList = [];       // valid memory-group numbers for this rig ([] = rig has no groups)
+var memCurrentGroup = 0;     // group the browser is currently reading/writing
+
+// Build the group list + selector from rig caps. memGroups is the highest
+// group number, memStart the lowest; a rig with no groups reports
+// memGroups < memStart, and we fall back to group 0 (byte is ignored by
+// the CI-V encoder for those rigs anyway).
+function setupMemoryGroups(memGroups, memStart) {
+    memGroupList = [];
+    for (var g = memStart; g <= memGroups; g++) memGroupList.push(g);
+    memCurrentGroup = memGroupList.length ? memGroupList[0] : 0;
+    var row = document.getElementById('memGroupRow');
+    var sel = document.getElementById('memGroupSelect');
+    if (memGroupList.length >= 2) {
+        sel.innerHTML = '';
+        for (var i = 0; i < memGroupList.length; i++) {
+            var o = document.createElement('option');
+            o.value = memGroupList[i];
+            o.textContent = String(memGroupList[i]).padStart(2, '0');
+            sel.appendChild(o);
+        }
+        sel.value = memCurrentGroup;
+        row.style.display = 'inline-flex';
+    } else {
+        row.style.display = 'none';
+    }
+}
+
+function onMemGroupChange() {
+    memCurrentGroup = parseInt(document.getElementById('memGroupSelect').value, 10) || 0;
+    refreshMemories();
+}
 
 function renderMemoryOverlay() {
     document.getElementById('memoryOverlay').classList.add('visible');
@@ -4174,7 +4217,7 @@ function refreshMemories() {
     document.getElementById('memoryList').innerHTML =
         '<div class="memory-empty">Scanning...</div>';
     document.getElementById('memScanStatus').textContent = 'scanning...';
-    send({ cmd: 'getMemories', start: 1, end: 99, group: 0 });
+    send({ cmd: 'getMemories', start: 1, end: 99, group: memCurrentGroup });
 }
 
 function renderMemoryList() {
@@ -4226,6 +4269,8 @@ function formatMemFreq(hz) {
 function handleMemoryChannel(msg) {
     var mem = msg.memory;
     if (!mem) return;
+    // Drop late replies from a group we've since switched away from.
+    if (memGroupList.length && (mem.group || 0) !== memCurrentGroup) return;
     var key = (mem.group || 0) * 65536 + mem.channel;
     if (mem.del || mem.empty) {
         delete memoryChannels[key];
@@ -4274,7 +4319,7 @@ function memoryWrite() {
 function memoryWriteConfirm() {
     var ch = parseInt(document.getElementById('memWriteCh').value);
     if (ch > 0) {
-        send({ cmd: 'writeMemory', channel: ch, group: 0 });
+        send({ cmd: 'writeMemory', channel: ch, group: memCurrentGroup });
         document.getElementById('memWritePrompt').classList.remove('visible');
         // Refresh after a short delay to see the new entry
         setTimeout(refreshMemories, 500);

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -4248,8 +4248,10 @@ function renderMemoryList() {
                 renderMemoryList();
             });
             row.addEventListener('click', function() {
-                if (m.frequency) send({ cmd: 'setFrequency', value: m.frequency });
-                if (m.mode) send({ cmd: 'setMode', value: m.mode });
+                // Recall on the radio so it restores tone / tone squelch /
+                // duplex offset from the channel — not just freq + mode.
+                send({ cmd: 'recallMemory', channel: m.channel, group: m.group || 0,
+                       frequency: m.frequency || 0, mode: m.mode || '' });
                 setPanel('default');
             });
         })(mem);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -2021,6 +2021,69 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
         queue->addUnique(priorityImmediate, queueItem(funcMemoryContents, QVariant::fromValue<uint>(val), false, 0));
         memoryScanTimer->start();
     }
+    else if (type == "recallMemory") {
+        // Recall a stored memory channel *on the radio* so it applies the
+        // channel's full contents — mode, filter, repeater tone / tone
+        // squelch, duplex direction and offset — not just frequency + mode.
+        if (!queue || !rigCaps) return;
+        int ch = cmd["channel"].toInt();
+        int group = cmd.contains("group") ? cmd["group"].toInt() : 0;
+        quint64 freqHz = cmd.contains("frequency") ? cmd["frequency"].toVariant().toULongLong() : 0;
+        if (ch <= 0) return;
+
+        // Icom selects a memory with CI-V 08; Kenwood / Yaesu use funcMemorySelect.
+        funcs selCmd = rigCaps->commands.contains(funcMemoryMode) ? funcMemoryMode
+                     : rigCaps->commands.contains(funcMemorySelect) ? funcMemorySelect
+                     : funcNone;
+
+        bool cmd29 = rigCaps->hasCommand29;
+        uchar rx = cmd29 ? (queue->getState().vfo == vfoSub ? 1 : 0) : 0;
+
+        if (selCmd == funcNone) {
+            // Rig can't select a channel directly — fall back to loading the
+            // stored freq + mode (no tone / offset, but better than nothing).
+            if (freqHz > 0) {
+                freqt f;
+                f.Hz = freqHz;
+                f.MHzDouble = freqHz / 1.0E6;
+                f.VFO = activeVFO;
+                vfoCommandType tf = queue->getVfoCommand(vfoA, rx, true);
+                queue->addUnique(priorityImmediate, queueItem(tf.freqFunc, QVariant::fromValue<freqt>(f), false, tf.receiver));
+            }
+            QString modeName = cmd["mode"].toString();
+            if (!modeName.isEmpty()) {
+                modeInfo m = stringToMode(modeName);
+                if (m.mk != modeUnknown) {
+                    vfoCommandType tm = queue->getVfoCommand(vfoA, rx, true);
+                    queue->addUnique(priorityImmediate, queueItem(tm.modeFunc, QVariant::fromValue<modeInfo>(m), false, tm.receiver));
+                }
+            }
+            requestVfoUpdate();
+            return;
+        }
+
+        // Icom recall (CI-V 08) acts on the currently selected band's memory
+        // bank. Rigs with a direct group-select command use it; the IC-9700 /
+        // IC-9100 have none, so nudge the VFO onto the band that owns this
+        // group first, using the channel's own stored frequency.
+        if (rigCaps->commands.contains(funcMemoryGroup)) {
+            queue->addUnique(priorityImmediate, queueItem(funcMemoryGroup, QVariant::fromValue<uchar>((uchar)group), false, 0));
+        } else if (selCmd == funcMemoryMode && freqHz > 0) {
+            freqt f;
+            f.Hz = freqHz;
+            f.MHzDouble = freqHz / 1.0E6;
+            f.VFO = activeVFO;
+            vfoCommandType tf = queue->getVfoCommand(vfoA, rx, true);
+            queue->addUnique(priorityImmediate, queueItem(tf.freqFunc, QVariant::fromValue<freqt>(f), false, tf.receiver));
+        }
+
+        // Enter memory mode / select the channel — the radio loads mode,
+        // filter, tone, tone squelch, duplex direction and offset from it.
+        queue->addUnique(priorityImmediate, queueItem(selCmd, QVariant::fromValue<uint>((uint)ch), false, 0));
+
+        // Read freq/mode back so the browser display follows the recalled channel.
+        requestVfoUpdate();
+    }
     else if (type == "writeMemory") {
         if (!queue || !rigCaps) return;
         int ch = cmd["channel"].toInt();

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -461,6 +461,14 @@ void webServer::receiveRigCaps(rigCapabilities *caps)
             }
             obj["filters"] = filters;
         }
+        // Memory-channel capabilities. memGroups is the highest group number
+        // (IC-9700: 3, one per band); memStart is the lowest (1 on the 9700,
+        // 0 on rigs whose groups are zero-based). Rigs with no groups report
+        // memGroups < memStart and the browser keeps group 0.
+        obj["hasMemories"] = rigCaps->commands.contains(funcMemoryContents) && !rigCaps->memParser.isEmpty();
+        obj["memGroups"] = rigCaps->memGroups;
+        obj["memStart"] = rigCaps->memStart;
+        obj["satMemories"] = rigCaps->satMemories;
         sendJsonToAll(obj);
 
         // Issue #76: rigs with an antenna selector but no periodic Antenna
@@ -2815,6 +2823,10 @@ QJsonObject webServer::buildInfoJson() const
             }
             info["filters"] = filters;
         }
+        info["hasMemories"] = rigCaps->commands.contains(funcMemoryContents) && !rigCaps->memParser.isEmpty();
+        info["memGroups"] = rigCaps->memGroups;
+        info["memStart"] = rigCaps->memStart;
+        info["satMemories"] = rigCaps->satMemories;
     } else {
         info["connected"] = false;
     }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -1636,16 +1636,23 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
         QString vfoName = cmd["value"].toString();
         // On cmd29 rigs (IC-7610/785x/9700/905) selecting a VFO means Main/Sub,
         // not A/B. funcSelectVFO in icomcommander maps vfo_t to the right command.
-        bool wantB = (vfoName == "B");
-        vfo_t v;
-        if (rigCaps && rigCaps->hasCommand29)
-            v = wantB ? vfoSub : vfoMain;
-        else
-            v = wantB ? vfoB : vfoA;
-        activeVfoLocal = v;
-        activeReceiver = wantB ? 1 : 0;
-        queue->addUnique(priorityImmediate, queueItem(funcSelectVFO, QVariant::fromValue<vfo_t>(v), false));
-        requestVfoUpdate();
+        if (vfoName == "MEM" || vfoName == "MEMO") {
+            // Memory mode — bare CI-V 08 (front-panel V/M). Leave
+            // activeVfoLocal alone so a later switch back to VFO returns here.
+            queue->addUnique(priorityImmediate, queueItem(funcSelectVFO, QVariant::fromValue<vfo_t>(vfoMem), false));
+            requestVfoUpdate();
+        } else {
+            bool wantB = (vfoName == "B");
+            vfo_t v;
+            if (rigCaps && rigCaps->hasCommand29)
+                v = wantB ? vfoSub : vfoMain;
+            else
+                v = wantB ? vfoB : vfoA;
+            activeVfoLocal = v;
+            activeReceiver = wantB ? 1 : 0;
+            queue->addUnique(priorityImmediate, queueItem(funcSelectVFO, QVariant::fromValue<vfo_t>(v), false));
+            requestVfoUpdate();
+        }
     }
     else if (type == "swapVFO") {
         // IC-7300/7100/705/etc use VFO Swap A/B; IC-7610/785x/9700/905 use Swap M/S.
@@ -2077,9 +2084,20 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
             queue->addUnique(priorityImmediate, queueItem(tf.freqFunc, QVariant::fromValue<freqt>(f), false, tf.receiver));
         }
 
-        // Enter memory mode / select the channel — the radio loads mode,
-        // filter, tone, tone squelch, duplex direction and offset from it.
+        // Select the channel — the radio loads mode, filter, tone, tone
+        // squelch, duplex direction and offset from it.
         queue->addUnique(priorityImmediate, queueItem(selCmd, QVariant::fromValue<uint>((uint)ch), false, 0));
+
+        // Icom: selecting a channel (CI-V 08 <ch>) does NOT flip the operating
+        // mode to memory — the radio stays on VFO A/B, so the recalled tone /
+        // offset never take effect. funcSelectVFO(vfoMem) sends the bare CI-V
+        // 08 that the front-panel V/M button uses and also marks the queue's
+        // rigState as memory mode. Distinct command from the line above, so
+        // addUnique here doesn't dedup the channel select. Kenwood / Yaesu
+        // funcMemorySelect already enters memory mode, so this is Icom-only.
+        if (selCmd == funcMemoryMode) {
+            queue->addUnique(priorityImmediate, queueItem(funcSelectVFO, QVariant::fromValue<vfo_t>(vfoMem), false, 0));
+        }
 
         // Read freq/mode back so the browser display follows the recalled channel.
         requestVfoUpdate();
@@ -2966,7 +2984,8 @@ QJsonObject webServer::buildStatusJson()
         if (freqCacheB.value.isValid()) {
             status["vfoBFrequency"] = (qint64)freqCacheB.value.value<freqt>().Hz;
         }
-        status["selectedVfo"] = (queue->getState().vfo == vfoSub) ? "B" : "A";
+        status["selectedVfo"] = (queue->getState().vfo == vfoMem) ? "MEM"
+                              : (queue->getState().vfo == vfoSub) ? "B" : "A";
     } else {
         bool bSelected = (queue->getState().vfo == vfoB);
         cacheItem selCache = queue->getCache(funcSelectedFreq, 0);
@@ -2980,7 +2999,7 @@ QJsonObject webServer::buildStatusJson()
             qint64 hz = (qint64)unselCache.value.value<freqt>().Hz;
             status[bSelected ? "vfoAFrequency" : "vfoBFrequency"] = hz;
         }
-        status["selectedVfo"] = bSelected ? "B" : "A";
+        status["selectedVfo"] = (queue->getState().vfo == vfoMem) ? "MEM" : bSelected ? "B" : "A";
     }
 
     // Mode
@@ -3214,7 +3233,8 @@ void webServer::receiveCache(cacheItem item)
     case funcSelectVFO:
     {
         vfo_t v = item.value.value<vfo_t>();
-        if (v == vfoMem || v == vfoUnknown) return;
+        if (v == vfoUnknown) return;
+        if (v == vfoMem) { update["selectedVfo"] = "MEM"; break; }
         bool isB = (v == vfoB || v == vfoSub);
         activeVfoLocal = v;
         activeReceiver = isB ? 1 : 0;


### PR DESCRIPTION
### Description
This PR fixes an issue in the memory browser where the application always attempted to read memory channel data using a hardcoded group `0`. 

For rigs like the IC-9700, hardcoding group `0` causes command rejection from the radio during memory read operations. The memory browser now dynamically uses the correct memory group, allowing memory channels to load properly.

### Changes
* Updated memory browser read logic to pass the actual target memory group instead of hardcoding `0`.
* Resolved CI-V command rejection issues on the IC-9700.

### Testing
* Verified with IC-9700 to ensure memory channel groups are read and displayed correctly without errors.