### PR TITLE
Advertise wfweb@k1fm.us as a plain support mailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ When reporting a bug, run wfweb with `--debug` and a log file to capture verbose
 wfweb --debug /tmp/wfweb-debug.log --lan 192.168.1.100 --lan-user myuser --lan-pass mypass
 ```
 
-This produces detailed, timestamped logs covering power on/off state transitions, VFO/split routing decisions, CI-V command traffic, and cache updates. Reproduce the issue, then share the log file with your bug report.
+This produces detailed, timestamped logs covering power on/off state transitions, VFO/split routing decisions, CI-V command traffic, and cache updates. Reproduce the issue, then attach the log file to your bug report — either on the [issue tracker](https://github.com/adecarolis/wfweb/issues) or by email (see [Bugs and feature requests](#bugs-and-feature-requests)).
 
 Without the filename argument, `--debug` writes to the default log location (`/tmp/wfweb-*.log`).
 
@@ -431,6 +431,15 @@ Password=
 ## Building from source
 
 See **[BUILDING.md](BUILDING.md)** for platform-specific prerequisites and build instructions (Linux, macOS, Windows).
+
+---
+
+## Bugs and feature requests
+
+Two ways to report a bug or ask for a new feature:
+
+- **Open a [GitHub issue](https://github.com/adecarolis/wfweb/issues)** — preferred, and lets others find and follow the report.
+- **Email [wfweb@k1fm.us](mailto:wfweb@k1fm.us)** — no GitHub account needed; it goes straight to the maintainer. Log files and screenshots are welcome as attachments.
 
 ---
 

--- a/resources/web-standalone/index.html
+++ b/resources/web-standalone/index.html
@@ -2052,6 +2052,11 @@ body.digi-open #bottomBar { grid-row: 5; }
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v3a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5a.5.5 0 100 1 .5.5 0 000-1zm2 0a.5.5 0 100 1 .5.5 0 000-1zM2 10a1 1 0 011-1h10a1 1 0 011 1v3a1 1 0 01-1 1H3a1 1 0 01-1-1v-3zm2 1.5a.5.5 0 100 1 .5.5 0 000-1zm2 0a.5.5 0 100 1 .5.5 0 000-1z"/></svg>
                     Get the server &mdash; native or Docker
                 </a>
+                <a href="mailto:wfweb@k1fm.us" class="splash-pill"
+                   title="Report a bug or request a feature by email. No account needed; logs and screenshots welcome.">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M22 6l-10 7L2 6"/></svg>
+                    Bugs &amp; feature requests &mdash; wfweb@k1fm.us
+                </a>
             </div>
         </div>
     </div>

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -1794,13 +1794,22 @@ body.digi-open #bottomBar { grid-row: 5; }
         <div id="splashHint" style="margin-top: 20px; font-size: 12px; color: #666;">Enable RX Audio</div>
         <div id="splashError"  style="margin-top: 16px; min-height: 18px; font-size: 12px; color: #f88;"></div>
 
-        <a href="https://github.com/adecarolis/wfweb" target="_blank" rel="noopener"
-           style="display: inline-flex; align-items: center; gap: 8px; margin-top: 32px; padding: 8px 16px; color: #888; text-decoration: none; font-size: 12px; border: 1px solid #333; border-radius: 6px; transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;"
-           onmouseover="this.style.color='#0cf'; this.style.borderColor='#0cf'; this.style.background='rgba(0,170,170,0.06)';"
-           onmouseout="this.style.color='#888'; this.style.borderColor='#333'; this.style.background='transparent';">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-            Source &amp; documentation
-        </a>
+        <div style="display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; margin-top: 32px;">
+            <a href="https://github.com/adecarolis/wfweb" target="_blank" rel="noopener"
+               style="display: inline-flex; align-items: center; gap: 8px; padding: 8px 16px; color: #888; text-decoration: none; font-size: 12px; border: 1px solid #333; border-radius: 6px; transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;"
+               onmouseover="this.style.color='#0cf'; this.style.borderColor='#0cf'; this.style.background='rgba(0,170,170,0.06)';"
+               onmouseout="this.style.color='#888'; this.style.borderColor='#333'; this.style.background='transparent';">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                Source &amp; documentation
+            </a>
+            <a href="mailto:wfweb@k1fm.us"
+               style="display: inline-flex; align-items: center; gap: 8px; padding: 8px 16px; color: #888; text-decoration: none; font-size: 12px; border: 1px solid #333; border-radius: 6px; transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;"
+               onmouseover="this.style.color='#0cf'; this.style.borderColor='#0cf'; this.style.background='rgba(0,170,170,0.06)';"
+               onmouseout="this.style.color='#888'; this.style.borderColor='#333'; this.style.background='transparent';">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M22 6l-10 7L2 6"/></svg>
+                Bugs &amp; feature requests &mdash; wfweb@k1fm.us
+            </a>
+        </div>
     </div>
     <div style="position: absolute; bottom: 20px; left: 20px; font-size: 11px; color: #555;">
         <span id="splashVersion">wfweb</span>


### PR DESCRIPTION
Follow-up to #90: the email address stays, now as a simple forward to the maintainer's inbox with no automation behind it.

- **README**: *Bugs and feature requests* section — GitHub issues preferred, `wfweb@k1fm.us` for reporters without an account; the *Debug logging* section links there for sharing logs.
- **Both splash screens**: a `mailto:wfweb@k1fm.us` pill next to the existing GitHub links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)