### PR TITLE
[Bug Fix] Restore of DATA OFF MOD on Browser/Tab Close

### DIFF
--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -5173,6 +5173,13 @@ function stopMic() {
     if (currentPanel === 'audiomiс') renderAudioMicOverlay();
 }
 
+// Explicitly release the web mic before the page is discarded.
+// This lets the server restore the radio's previous DATA OFF MOD setting
+// while the WebSocket is still alive.
+window.addEventListener('pagehide', function() {
+    if (micEnabled) stopMic();
+});
+
 function handleAudioData(buffer) {
     if (!audioEnabled) return;
     if (buffer.byteLength < 8) return;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -39,6 +39,18 @@
 // classic-FreeDV ALC loop can't affect RADE.
 static constexpr float RADE_TX_GAIN = 0.4f;
 
+// Return true when the selected modulation input already includes USB.
+// In that case a USB-attached web mic can transmit without changing
+// DATA MOD OFF and unnecessarily disabling the radio's other inputs.
+static bool inputIncludesUsb(const rigInput &input)
+{
+    // The numeric input type/Num field is not consistent across .rig
+    // files. The input Name is authoritative. Some Icom rig definitions
+    // abbreviate MIC+USB as "M/U".
+    return input.name.contains("USB", Qt::CaseInsensitive)
+        || input.name.compare("M/U", Qt::CaseInsensitive) == 0;
+}
+
 webServer::webServer(QObject *parent) :
     QObject(parent)
 {
@@ -1871,23 +1883,40 @@ void webServer::handleCommand(QWebSocket *client, const QJsonObject &cmd)
             // USB-attached rigs use "USB". Forcing USB on a LAN rig (e.g. IC-7610,
             // IC-7300 MK2, IC-9700) keys the radio with no modulation. (issue #72)
             cacheItem cache = queue->getCache(funcDATAOffMod, 0);
+            bool inputAlreadySuitable = false;
             if (cache.value.isValid()) {
-                savedDataOffMod = cache.value.value<rigInput>();
-                dataOffModSaved = true;
+                rigInput currentInput = cache.value.value<rigInput>();
+
+                // For a locally USB-attached rig, don't replace a combined
+                // input such as MIC,USB with USB-only. USB audio is already
+                // accepted by the current setting.
+                if (!lanMode && inputIncludesUsb(currentInput)) {
+                    inputAlreadySuitable = true;
+                    qInfo() << "Web: DATA MOD OFF already includes USB:"
+                            << currentInput.name << "- leaving unchanged";
+                } else {
+                    savedDataOffMod = currentInput;
+                    dataOffModSaved = true;
+                }
             }
+
             // Reset the LAN mic-session state so each session coalesces and
             // logs afresh.
             micLanTxLogged = false;
             micLanTxBuffer.clear();
+
             // Pick the mod input from rig capabilities: LAN when LAN-connected,
             // otherwise USB (shared with the packet TX path).
-            rigInput modInput;
-            if (pickDataModInput(modInput)) {
-                queue->addUnique(priorityImmediate, queueItem(funcDATAOffMod, QVariant::fromValue<rigInput>(modInput), false, 0));
-                qInfo() << "Web: Set DATA MOD OFF to" << modInput.name << "for web mic";
-            } else {
-                qInfo() << "Web: No suitable mod input found in rig capabilities";
+            if (!inputAlreadySuitable) {
+                rigInput modInput;
+                if (pickDataModInput(modInput)) {
+                    queue->addUnique(priorityImmediate, queueItem(funcDATAOffMod, QVariant::fromValue<rigInput>(modInput), false, 0));
+                    qInfo() << "Web: Set DATA MOD OFF to" << modInput.name << "for web mic";
+                } else {
+                    qInfo() << "Web: No suitable mod input found in rig capabilities";
+                }
             }
+
             micActiveClient = client;
             if (usbAudioOutput) {
                 // Stop any previous session cleanly, then arm the pre-buffer.


### PR DESCRIPTION
# Summary

This PR fixes browser microphone handling so that WFWEB does not unnecessarily disable the radio's physical microphone, and restores the previous `DATA OFF MOD` setting when the browser page is closed.

## Background

When the WFWEB browser microphone is enabled, WFWEB selects the appropriate modulation input for the active audio transport.

On my IC-7300, this resulted in:

`DATA OFF MOD: MIC,USB` → `USB`

Although USB audio worked correctly for WFWEB, this removed the physical microphone as a modulation source. After returning to the radio, PTT would key the transmitter but there would be no microphone audio, `ALC`, or `Po` until `DATA OFF MOD` was manually restored.

WFWEB already saves and restores the previous setting when the browser microphone is explicitly disabled, but closing the browser tab did not call `stopMic()`, so that cleanup path was not reliably triggered.

## Changes

This PR makes two related changes.

### Preserve an Existing USB-Capable Input

Before changing `DATA OFF MOD`, WFWEB now checks whether the current input already supports USB audio.

For locally USB-connected radios, a combined input such as the IC-7300's `M/U` (`MIC,USB`) is already suitable for the browser microphone, so WFWEB leaves it unchanged rather than replacing it with USB-only.

The existing `pickDataModInput()` path is still used when the current setting does not already support the required audio transport.

### Restore the Previous Input on Page Close

A `pagehide` event listener now calls `stopMic()` when the browser microphone is active.

This allows the existing `enableMic=false` server-side cleanup path to restore a temporarily changed `DATA OFF MOD` setting while the WebSocket is still available.

## Tested

Tested with an IC-7300 connected by USB.

With:

`DATA OFF MOD = MIC,USB`

Verified that:

* Enabling the WFWEB browser microphone leaves `DATA OFF MOD` at `MIC,USB`.
* Browser microphone TX continues to work normally.
* The physical microphone remains usable after using WFWEB.
* Explicitly disabling the browser microphone restores a temporarily changed modulation input.
* Closing the browser tab also restores a temporarily changed modulation input.

Closes #95
